### PR TITLE
configury: add the --enable-blas-mt option

### DIFF
--- a/config/acx_blas.m4
+++ b/config/acx_blas.m4
@@ -9,12 +9,25 @@ acx_blas_ok=no
 
 AC_ARG_WITH(blas_libs,
         [AC_HELP_STRING([--with-blas-libs=<libs>], [Use BLAS libraries <libs>],[32])])
+
+AC_ARG_ENABLE(blas-mt,AC_HELP_STRING([--enable-blas-mt],
+            [BLAS library is multi-threaded]),[],[])
+
+
 case $with_blas_libs in
         yes | "") ;;
         no) acx_blas_ok=disable ;;
         -* | */* | *.a | *.so | *.so.* | *.o) BLAS_LIBS="$with_blas_libs" ;;
         *) BLAS_LIBS="-l$with_blas_libs" ;;
 esac
+
+if test "x$enable_blas_mt" = "xyes"; then
+    have_blas_mt=1
+else
+    have_blas_mt=0
+fi
+
+AC_DEFINE(HAVE_BLAS_MT,$have_blas_mt,[Define if you have a multi-threaded BLAS library.])
 
 # Set fortran linker names of BLAS functions to check for.
 caxpy="caxpy"

--- a/src/modules/mod_wrapper_omp.F
+++ b/src/modules/mod_wrapper_omp.F
@@ -103,9 +103,9 @@ module wrapper_omp
      character,intent(in) :: TRANS
      real(SP), intent(in) :: A(LDA,*),X(*)
      real(SP), intent(out):: Y(*)
-#if defined _OPENMP && defined _DOUBLE
+#if defined _OPENMP && defined _DOUBLE && !HAVE_BLAS_MT
      call DGEMV_omp(TRANS,M,N,ALPHA,A,LDA,X,INCX,BETA,Y,INCY)
-#elif defined _OPENMP && !defined _DOUBLE
+#elif defined _OPENMP && !defined _DOUBLE && !HAVE_BLAS_MT
      call SGEMV_omp(TRANS,M,N,ALPHA,A,LDA,X,INCX,BETA,Y,INCY)
 #elif defined _DOUBLE
      call DGEMV(TRANS,M,N,ALPHA,A,LDA,X,INCX,BETA,Y,INCY)
@@ -120,9 +120,9 @@ module wrapper_omp
      character,   intent(in) :: TRANS
      complex(SP), intent(in) :: A(LDA,*),X(*)
      complex(SP), intent(out):: Y(*)
-#if defined _OPENMP && defined _DOUBLE
+#if defined _OPENMP && defined _DOUBLE && ! HAVE_BLAS_MT
      call ZGEMV_omp(TRANS,M,N,ALPHA,A,LDA,X,INCX,BETA,Y,INCY)
-#elif defined _OPENMP && !defined _DOUBLE
+#elif defined _OPENMP && !defined _DOUBLE && ! HAVE_BLAS_MT
      call CGEMV_omp(TRANS,M,N,ALPHA,A,LDA,X,INCX,BETA,Y,INCY)
 #elif defined _DOUBLE
      call ZGEMV(TRANS,M,N,ALPHA,A,LDA,X,INCX,BETA,Y,INCY)
@@ -136,9 +136,9 @@ module wrapper_omp
      complex(SP), intent(in) :: A(msize,*),X(*)
      complex(SP), intent(out):: Y(*)
      character,   intent(in) :: TRANS
-#if defined _OPENMP && defined _DOUBLE
+#if defined _OPENMP && defined _DOUBLE && !HAVE_BLAS_MT
      call ZGEMV_omp(TRANS,msize,msize,cONE,A,msize,X,1,cZERO,Y,1)
-#elif defined _OPENMP && !defined _DOUBLE
+#elif defined _OPENMP && !defined _DOUBLE && !HAVE_BLAS_MT
      call CGEMV_omp(TRANS,msize,msize,cONE,A,msize,X,1,cZERO,Y,1)
 #elif defined _DOUBLE
      call ZGEMV(TRANS,msize,msize,cONE,A,msize,X,1,cZERO,Y,1)
@@ -152,9 +152,9 @@ module wrapper_omp
      real(SP), intent(in) :: A(msize,*),X(*)
      real(SP), intent(out):: Y(*)
      character,intent(in) :: TRANS
-#if defined _OPENMP && defined _DOUBLE
+#if defined _OPENMP && defined _DOUBLE && !HAVE_BLAS_MT
      call DGEMV_omp(TRANS,msize,msize,1._SP,A,msize,X,1,0._SP,Y,1)
-#elif defined _OPENMP && !defined _DOUBLE
+#elif defined _OPENMP && !defined _DOUBLE && !HAVE_BLAS_MT
      call SGEMV_omp(TRANS,msize,msize,1._SP,A,msize,X,1,0._SP,Y,1)
 #elif defined _DOUBLE
      call DGEMV(TRANS,msize,msize,1._SP,A,msize,X,1,0._SP,Y,1)


### PR DESCRIPTION
using the --enable-blas-mt option directs YAMBO to use the external BLAS when built with OpenMP
external BLAS can be multithreaded (for example the Fujitsu SSL2BLAMP library, or Intel MKL with the right options)
and is generally faster than the embedded BLAS subroutines.