### PR TITLE
Update .objects

### DIFF
--- a/ypp/el-ph/.objects
+++ b/ypp/el-ph/.objects
@@ -1,4 +1,4 @@
-#if defined _YPP_ELPH
+#if defined _YPP_ELPH || _YPP_RT
 ELPH_objects = ELPH_databases.o ELPH_databases_IO_elemental.o ELPH_databases_IO_pol_and_freqs.o ELPH_databases_IO_grids_check.o \
                ELPH_databases_IO_transfer_and_write.o ELPH_databases_IO_gkkp_expand.o \
                ELPH_eliashberg_dos.o ELPH_general_gFsq.o ELPH_excitonic_gkkp.o ELPH_atomic_amplitude.o 


### PR DESCRIPTION
Fix compilation error when making ypp_rt on MacOS(Yambo 5.X specific) when using gcc11 or above. Please refer http://www.yambo-code.org/forum/viewtopic.php?f=1&t=2025  and http://www.yambo-code.org/forum/viewtopic.php?p=10390#p10390 posts for the error. 