### PR TITLE
Inconsistent usage of petsc variables in slepc routines 

### DIFF
--- a/src/bse/K_multiply_by_V_slepc.F
+++ b/src/bse/K_multiply_by_V_slepc.F
@@ -46,7 +46,7 @@ subroutine K_multiply_by_V_slepc(slepc_mat,vi,vo,ierr)
  implicit none
  !
  PetscFortranComplex  :: tmp_value(1)
- PetscFortranInt      :: H_pos(1)
+ PetscInt             :: H_pos(1)
  PetscErrorCode       :: ierr
  !
  VecScatter           :: ctx

--- a/src/bse/K_multiply_by_V_slepc.F
+++ b/src/bse/K_multiply_by_V_slepc.F
@@ -45,8 +45,8 @@ subroutine K_multiply_by_V_slepc(slepc_mat,vi,vo,ierr)
  !
  implicit none
  !
- PetscFortranComplex  :: tmp_value(1)
- PetscInt             :: H_pos(1)
+ PetscScalar          :: tmp_value(1)
+ PetscInt             :: H_pos(1), pet_one
  PetscErrorCode       :: ierr
  !
  VecScatter           :: ctx
@@ -60,6 +60,7 @@ subroutine K_multiply_by_V_slepc(slepc_mat,vi,vo,ierr)
  !
  ! create scattering context vi (distributed) -> x (local)
  !
+ pet_one = 1
  call VecScatterCreateToAll(vi,ctx,x,ierr);
  !
  ! scatter from vi (distributed) -> x (local)
@@ -76,7 +77,7 @@ subroutine K_multiply_by_V_slepc(slepc_mat,vi,vo,ierr)
    do i_c=1,BS_T_grp(i_g)%size
      H_pos=start_index+i_c
      !SLEPC funcitons expect C indexes both in Fortran and C
-     call VecGetValues( x, 1, H_pos, tmp_value, ierr )
+     call VecGetValues( x, pet_one, H_pos, tmp_value, ierr )
      Slepc_v%Vi(i_g)%fragment(i_c)=cmplx(tmp_value(1),kind=SP)
    enddo
  enddo
@@ -109,11 +110,11 @@ subroutine K_multiply_by_V_slepc(slepc_mat,vi,vo,ierr)
      H_pos=start_index+i_c
      tmp_value=cmplx(Slepc_v%Vo(i_g)%fragment(i_c))
      !SLEPC funcitons expect C indexes both in Fortran and C
-     call VecSetValues( vo, 1, H_pos, tmp_value, INSERT_VALUES, ierr )
+     call VecSetValues( vo, pet_one, H_pos, tmp_value, INSERT_VALUES, ierr )
      if(BSS_slepc_double_grp) then
        ! Expand vo to anti-resonant block
        H_pos=start_index_dg+i_c
-       call VecSetValues( vo, 1, H_pos, fac*conjg(tmp_value), INSERT_VALUES, ierr )
+       call VecSetValues( vo, pet_one, H_pos, fac*conjg(tmp_value), INSERT_VALUES, ierr )
      endif
    enddo
  enddo

--- a/src/bse/K_multiply_by_V_transpose_slepc.F
+++ b/src/bse/K_multiply_by_V_transpose_slepc.F
@@ -46,7 +46,7 @@ subroutine K_multiply_by_V_transpose_slepc(slepc_mat,vi,vo,ierr)
  implicit none
  !
  PetscFortranComplex  :: tmp_value(1)
- PetscFortranInt      :: H_pos(1)
+ PetscInt             :: H_pos(1)
  PetscErrorCode       :: ierr
  !
  VecScatter           :: ctx

--- a/src/bse/K_multiply_by_V_transpose_slepc.F
+++ b/src/bse/K_multiply_by_V_transpose_slepc.F
@@ -45,8 +45,8 @@ subroutine K_multiply_by_V_transpose_slepc(slepc_mat,vi,vo,ierr)
  !
  implicit none
  !
- PetscFortranComplex  :: tmp_value(1)
- PetscInt             :: H_pos(1)
+ PetscScalar          :: tmp_value(1)
+ PetscInt             :: H_pos(1), pet_one 
  PetscErrorCode       :: ierr
  !
  VecScatter           :: ctx
@@ -58,6 +58,8 @@ subroutine K_multiply_by_V_transpose_slepc(slepc_mat,vi,vo,ierr)
  integer              :: n, i_g, i_g_start, i_c, start_index, start_index_dg
  !
  ! create scattering context vi (distributed) -> x (local)
+ !
+ pet_one = 1
  !
  call VecScatterCreateToAll(vi,ctx,x,ierr);
  !
@@ -75,7 +77,7 @@ subroutine K_multiply_by_V_transpose_slepc(slepc_mat,vi,vo,ierr)
    do i_c=1,BS_T_grp(i_g)%size
      H_pos=start_index+i_c
      !SLEPC funcitons expect C indexes both in Fortran and C
-     call VecGetValues( x, 1, H_pos, tmp_value, ierr )
+     call VecGetValues( x, pet_one, H_pos, tmp_value, ierr )
      Slepc_v%Vi(i_g)%fragment(i_c)=cmplx(tmp_value(1),kind=SP)
    enddo
  enddo
@@ -108,11 +110,11 @@ subroutine K_multiply_by_V_transpose_slepc(slepc_mat,vi,vo,ierr)
      H_pos=start_index+i_c
      tmp_value=cmplx(Slepc_v%Vo(i_g)%fragment(i_c))
      !SLEPC funcitons expect C indexes both in Fortran and C
-     call VecSetValues( vo, 1, H_pos, tmp_value, INSERT_VALUES, ierr )
+     call VecSetValues( vo, pet_one, H_pos, tmp_value, INSERT_VALUES, ierr )
      if(BSS_slepc_double_grp) then
        ! Expand vo to anti-resonant block
        H_pos=start_index_dg+i_c
-       call VecSetValues( vo, 1, H_pos, fac*conjg(tmp_value), INSERT_VALUES, ierr )
+       call VecSetValues( vo, pet_one, H_pos, fac*conjg(tmp_value), INSERT_VALUES, ierr )
      endif
    enddo
  enddo

--- a/src/bse/K_shell_matrix.F
+++ b/src/bse/K_shell_matrix.F
@@ -52,7 +52,7 @@ subroutine K_shell_matrix(i_BS_mat,slepc_mat)
  Mat,     intent(out) :: slepc_mat
  !
  integer          :: i_B, i_r, i_c, i_Tk, i_Tp, grp_fac
- PetscFortranInt  :: SL_H_dim,SL_K_dim
+ PetscInt         :: SL_H_dim,SL_K_dim
  PetscErrorCode   :: ierr
  external K_multiply_by_V_slepc
  external K_multiply_by_V_transpose_slepc

--- a/src/bse/K_stored_in_a_slepc_matrix.F
+++ b/src/bse/K_stored_in_a_slepc_matrix.F
@@ -54,7 +54,7 @@ subroutine K_stored_in_a_slepc_matrix(i_BS_mat,slepc_mat)
  !
  integer     :: i_c,i_r,i_Tk,i_Tp,i_B,H_shift(2)
  PetscFortranComplex :: Mij
- PetscFortranInt     :: H_pos(2),SL_K_dim(2),SL_H_dim
+ PetscInt            :: H_pos(2),SL_K_dim(2),SL_H_dim
  PetscErrorCode      :: ierr
  !
  if(     BS_K_coupling) SL_H_dim=BS_H_dim

--- a/src/bse/K_stored_in_a_slepc_matrix.F
+++ b/src/bse/K_stored_in_a_slepc_matrix.F
@@ -52,8 +52,8 @@ subroutine K_stored_in_a_slepc_matrix(i_BS_mat,slepc_mat)
  integer, intent(in)  :: i_BS_mat
  Mat,     intent(out) :: slepc_mat
  !
- integer     :: i_c,i_r,i_Tk,i_Tp,i_B,H_shift(2)
- PetscFortranComplex :: Mij
+ integer             :: i_c,i_r,i_Tk,i_Tp,i_B,H_shift(2)
+ PetscScalar         :: Mij
  PetscInt            :: H_pos(2),SL_K_dim(2),SL_H_dim
  PetscErrorCode      :: ierr
  !

--- a/src/linear_algebra/MATRIX_slepc.F
+++ b/src/linear_algebra/MATRIX_slepc.F
@@ -260,7 +260,7 @@ subroutine MATRIX_slepc(M_slepc,l_target_energy,n_eig,V_right,V_left,E_real,E_cm
  call EPSGetConverged(eps,nconv,ierr)
  call msg( 'srn', '[SLEPC] Number of converged states        ', int(nconv))
  if ( nconv < n_eig ) then
-   call warning(' [SLEPC] requested '//trim(intc(n_eig))//' but converged '//trim(intc(nconv))//' eigenvalues')
+   call warning(' [SLEPC] requested '//trim(intc(n_eig))//' but converged '//trim(intc(int(nconv,4)))//' eigenvalues')
    n_eig = nconv
  endif
  !
@@ -400,8 +400,8 @@ subroutine MyEPSMonitor(eps,its,nconv,eigr,eigi,errest,nest,dummy,ierr)
  endif
  !
  ! write the number of converged eigenvalues
- call msg('s', '[SLEPC] Iteration #'// trim(intc(its))// ' - converged States '&
-&           // trim(intc(nconv)) //' - error ', maxerror)
+ call msg('s', '[SLEPC] Iteration #'// trim(intc(int(its,4)))// ' - converged States '&
+&           // trim(intc(int(nconv,4))) //' - error ', maxerror)
  !
  !Slepc_v%it=0 !Slepc_v%it+1 !its
  !


### PR DESCRIPTION
Dear developers,

I noticed that petsc datatypes are incorrectly used in slepc files contained in src/bse folder. The code compiles successfully now as the default petsc datatypes coincidently match the other petsc data types used in the yambo code. For example, the build fails when petsc is compiled with --with-64-bit-indices. At least in my case, this is important as there is overflow of indices due to large bse diagonalization and more requested eigenvalues. Below is the error when I tried to diagonalize matrix with slepc algorithm and made me compile petsc with 64bit-indices:

```
[0]PETSC ERROR: --------------------- Error Message --------------------------------------------------------------
[0]PETSC ERROR: No support for this operation for this object type
[0]PETSC ERROR: Product of two integer 18501 156800 overflow, you must ./configure PETSc with --with-64-bit-indices for the case you are running
[0]PETSC ERROR: See https://www.mcs.anl.gov/petsc/documentation/faq.html for trouble shooting.
[0]PETSC ERROR: Petsc Release Version 3.13.4, Aug 01, 2020
[0]PETSC ERROR: Unknown Name on a  named aion-0033 by mnalabothula Tue Mar 15 11:39:21 2022

```

In the above error, 18500 is the requested eigen values and 156800 is the size of the bse matrix. Also in src/linear_algebra/MATRIX_slepc.F, input parameters for function "intc()" are incorrect. intc() can only take 4 byte integers, and petscInt can also be an 8byte integer and yambo build fails when petscInt is not a 4-byte integer (by default, petscInt is 4 byte, so the code compiles successfully now). All the Vec and Mat C/fortran function/subroutines are defined on PetscInt and PetscScalar so using them is suggestable to be consistent with any petsc build

