### PR TITLE
Introduce Chunking in BSE KERNAL IO

### DIFF
--- a/src/Yio/def_variable_bulk.F
+++ b/src/Yio/def_variable_bulk.F
@@ -21,7 +21,7 @@
 ! Software Foundation, Inc., 59 Temple Place - Suite 330,Boston,
 ! MA 02111-1307, USA or visit http://www.gnu.org/copyleft/gpl.txt.
 !
-subroutine def_variable_bulk(ID,VAR,VAR_ID,VAR_SZ,VAR_KIND,dim_names,par_io_kind,silent)
+subroutine def_variable_bulk(ID,VAR,VAR_ID,VAR_SZ,VAR_KIND,dim_names,par_io_kind,silent,chunksize)
  !
  use netcdf
  use com,        ONLY:fat_log
@@ -40,6 +40,7 @@ subroutine def_variable_bulk(ID,VAR,VAR_ID,VAR_SZ,VAR_KIND,dim_names,par_io_kind
  character(schlen), optional, intent(in) :: dim_names(:)
  character(*),      optional, intent(in) :: par_io_kind
  logical,           optional, intent(in) :: silent
+ integer,           optional, intent(in) :: chunksize(:) ! Chunking parameter
  !
  ! Work Space
  !
@@ -102,6 +103,14 @@ subroutine def_variable_bulk(ID,VAR,VAR_ID,VAR_SZ,VAR_KIND,dim_names,par_io_kind
      if (present(par_io_kind).and.io_PAR_comm(ID)/=mpi_comm_null) then
        nf_error=nf90_var_par_access(io_unit(ID), io_netcdf_var(ID,VAR_ID), netcdf_par_io_kind)
        call netcdf_call(nf_error,ID,VAR=VAR)
+     endif
+     ! Add chunking to the variable. 
+     if (present(chunksize)) then
+       if (PRODUCT(chunksize)>0) then
+         ! Only chuck if all the dims are greater than 0
+         nf_error = nf90_def_var_chunking(io_unit(ID), io_netcdf_var(ID,VAR_ID), NF90_CHUNKED, chunksize)
+         call netcdf_call(nf_error,ID,VAR=VAR)
+       endif
      endif
 #endif
    endif

--- a/src/io_parallel/io_BS_PAR_init.F
+++ b/src/io_parallel/io_BS_PAR_init.F
@@ -44,6 +44,7 @@ integer function io_BS_PAR_init(iq,ID,mode)
  logical           :: def_var, io_var
  integer(IPL)      :: BS_lin_size
  integer           :: n_vars, i1,i2, i_rep,i_var, BSK_n_dims,n_replica
+ integer           :: chunksize(3) ! Chunking Dimensions
  !
  io_BS_PAR_init=-1
  !
@@ -87,6 +88,10 @@ integer function io_BS_PAR_init(iq,ID,mode)
  ch(1,:)="BSE_RESONANT"
  ch(2,:)="BSE_COUPLING"
  ch(3,:)="BSE_ANTI-RESONANT"
+ ! Intitiate chucking array with 0
+ chunksize(1) = 2 !! Complex dim
+ chunksize(2) = 0
+ chunksize(3) = 0 
  !
  if (.not.BS_K_coupling     ) n_vars=1
  if (     BS_K_coupling     ) n_vars=2
@@ -148,6 +153,13 @@ integer function io_BS_PAR_init(iq,ID,mode)
      BS_IO_dim(:,2) = (/BS_K_dim(1),BS_K_dim(1)/)
    endif
    !
+   ! For now we adapt chunking only to 2D_standard
+   ! For SP, we chunk in 2MB and double 4MB. These are in general 
+   ! small chunk sizes. 
+   chunksize(2) = 512
+   chunksize(3) = 512
+   ! If BSE matrix is <512, we do not chunk.
+   if (BS_K_dim(1) < 512) chunksize(3) = 0
  end select
  !
  do i_rep=1,n_replica
@@ -162,7 +174,8 @@ integer function io_BS_PAR_init(iq,ID,mode)
      endif
      if(trim(mode)=="full" .or. trim(mode)=="compressed_mat") &
 &           call def_variable_bulk(ID,trim(ch(i_var,i_rep)),         1+(i_var-1)*2+(i_rep-1)*8,&
-&                [2,BS_IO_dim(1:BSK_n_dims,i_var)],SP,dim_names(1:BSK_n_dims+1,i_var),par_io_kind='independent')
+&                [2,BS_IO_dim(1:BSK_n_dims,i_var)],SP,dim_names(1:BSK_n_dims+1,i_var),&
+&                 par_io_kind='independent',chunksize=chunksize)
      if(                        trim(mode)=="compressed_head") &
 &           call def_variable_bulk(ID,trim(ch(i_var,i_rep))//"_DONE",2+(i_var-1)*2+(i_rep-1)*8,&
 &                BS_IO_dim(1:BSK_n_dims,i_var) , 0,dim_names(2:BSK_n_dims+1,i_var),par_io_kind='independent')

--- a/src/modules/mod_IO_interfaces.F
+++ b/src/modules/mod_IO_interfaces.F
@@ -110,7 +110,7 @@ module IO_int
      character(*),      optional, intent(in) :: par_io_kind
    end subroutine def_variable_elemental
    !
-   subroutine def_variable_bulk(ID,VAR,VAR_ID,VAR_SZ,VAR_KIND,dim_names,par_io_kind,silent)
+   subroutine def_variable_bulk(ID,VAR,VAR_ID,VAR_SZ,VAR_KIND,dim_names,par_io_kind,silent,chunksize)
      use pars,              ONLY:schlen
      integer,      intent(in)  :: ID
      character(*), intent(in)  :: VAR
@@ -120,6 +120,7 @@ module IO_int
      character(schlen), optional, intent(in) :: dim_names(:)
      character(*),      optional, intent(in) :: par_io_kind
      logical,           optional, intent(in) :: silent
+     integer,           optional, intent(in) :: chunksize(:)
    end subroutine def_variable_bulk
    !
    subroutine io_variable_elemental(ID,VAR,CHECK,WARN,OP,     &


### PR DESCRIPTION
Dear All,

It looks like Yambo does not adapt chunking when writing large files. I guess it is known that the performance is awful (in parallel IO mode) when writing decently large BSE kernels, In fact when building sufficiently large kernels( > 10 Gb), significant amount of the time is spent in IO severely hitting the performance. The root cause of this issue from software point is that Yambo does not chunk the variables when writing large datasets and by default netCDF does not adapt chunking. 

This PR introduces Chunking to write functions and adapts chunking when writing BSE kernel (for now only in "2D standard" mode and in parallel IO mode). Subsequently, chunking should be adapted through out the code when writing other variables with very large files sizes. This will in general bring the performance on par with non parallel IO builds.

Please note that as said, this is only a fix from software point of view. As hardware in general have tweaks to improve the parallel IO. For example, ```lustre``` has striping mechanism when you can write parts of files to different OST (with set strip to set number of fragmentation parts and size of each part). As always the users must consult the HPC documentations.


Best regards,
Murali
 

ps. I do not have access to the test suite, but I tried them for few test cases. please run the test suite and let me know if it fails any cases.