### PR TITLE
Enable CUDA in SLEPc solver

### DIFF
--- a/src/bse/K_diago_driver.F
+++ b/src/bse/K_diago_driver.F
@@ -444,7 +444,7 @@ subroutine K_diago_driver(iq,W,X_static)
        BSS_n_eig = 1
      endif
      !
-     call PetscInitialize(PETSC_NULL_CHARACTER,ierr)
+     call SlepcInitialize(PETSC_NULL_CHARACTER,ierr)
      !
    end subroutine K_slepc_local_init
    !
@@ -458,6 +458,7 @@ subroutine K_diago_driver(iq,W,X_static)
        call PARALLEL_Haydock_VEC_COMMs('reset')
      endif
      !
+     call SlepcFinalize(ierr)
    end subroutine K_slepc_local_free
 #endif
    !

--- a/src/bse/K_stored_in_a_slepc_matrix.F
+++ b/src/bse/K_stored_in_a_slepc_matrix.F
@@ -18,6 +18,7 @@ subroutine K_stored_in_a_slepc_matrix(i_BS_mat,slepc_mat)
  use BS,             ONLY:BS_K_dim,BS_H_dim,BS_blk,n_BS_blks,BS_K_coupling,&
  &                        BS_res_ares_n_mat,l_BS_ares_from_res
  use BS_solvers,     ONLY:BSS_eh_E,BSS_eh_W,BSS_perturbative_width
+ use cuda_m,         ONLY:have_cuda
  !
 #include <petsc/finclude/petscsys.h>
 #include <petsc/finclude/petscvec.h>
@@ -50,6 +51,11 @@ subroutine K_stored_in_a_slepc_matrix(i_BS_mat,slepc_mat)
  call MatCreate(PETSC_COMM_WORLD,slepc_mat,ierr)
  call MatSetSizes(slepc_mat,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim,SL_H_dim,ierr)
  call MatSetType(slepc_mat, MATMPIDENSE,ierr)
+
+#if defined(PETSC_HAVE_CUDA)
+ if(have_cuda) call MatSetType(slepc_mat,MATDENSECUDA,ierr)
+#endif
+
  call MatSetUp(slepc_mat,ierr)
  ! 
  ! filling of the slepc_mat

--- a/src/linear_algebra/MATRIX_slepc.F
+++ b/src/linear_algebra/MATRIX_slepc.F
@@ -90,7 +90,6 @@ subroutine MATRIX_slepc(M_slepc,l_target_energy,n_eig,V_right,V_left,E_real,E_cm
  ! Non hermitian not implemented yet!
  !
  call MatGetSize(M_slepc,n,j,ierr)
- call SlepcInitialize(PETSC_NULL_CHARACTER,ierr)
  call MPI_Comm_rank(PETSC_COMM_WORLD,rank,ierr)
  !
  call MatCreateVecs(M_slepc,xr,xr_left,ierr)
@@ -354,7 +353,6 @@ subroutine MATRIX_slepc(M_slepc,l_target_energy,n_eig,V_right,V_left,E_real,E_cm
  call EPSDestroy(eps,ierr)
  call VecDestroy(xr,ierr)
  call VecDestroy(xr_left,ierr)
- call SlepcFinalize(ierr)
  !
 end subroutine
 !


### PR DESCRIPTION
We use the variable `have_cuda` to check if Yambo is configured with CUDA. Additionally we use the PETSc macro `PETSC_HAVE_CUDA` to check if PETSc is configured with CUDA. 

We changed the location of `SlepcInitialize` and `SlepcFinalize` to cover all relevant code.

@joseeroman 