### PR TITLE
SLEPc solver with nest matrix format

### DIFF
--- a/doc/README.slepc
+++ b/doc/README.slepc
@@ -24,9 +24,12 @@ BSSNEig
 Choose the number of eigenstates to calculate from lower energy to higher
 The default is to calculate 1% of the states of the hamiltonian.
 
-BSSSlepcShell
-This creates a PETSC Shell matrix intead of re-allocating a PETSC sparse matrix.
-This is more memory efficient and yields the same results as with the re-allocation.
+BSSSlepcMatrix
+Choose the format of the matrix for the SLEPc solver. The options are:
+'shell'          -> This is the default option. Creates a PETSc Shell matrix instead of re-allocating a PETSc matrix. 
+                    The most memory efficient but less time efficient.
+'explicit'       -> Creates the PETSc matrix. Requires more memory but it is more time efficient. 
+'explicit-debug' -> Same as explicit but without memory optimization for the coupling case.
 
 BSSEnTarget
 Choose this value to look for eigenvalues close to a certain energy

--- a/doc/README.slepc
+++ b/doc/README.slepc
@@ -24,7 +24,7 @@ BSSNEig
 Choose the number of eigenstates to calculate from lower energy to higher
 The default is to calculate 1% of the states of the hamiltonian.
 
-BSSSlepcMatrix
+BSSSlepcMatrixFormat
 Choose the format of the matrix for the SLEPc solver. The options are:
 'shell'          -> This is the default option. Creates a PETSc Shell matrix instead of re-allocating a PETSc matrix. 
                     The most memory efficient but less time efficient.

--- a/src/bse/.objects
+++ b/src/bse/.objects
@@ -1,5 +1,5 @@
 #if defined _SLEPC && !defined _NL
-SLEPC_objects = K_stored_in_a_slepc_matrix.o K_shell_matrix.o \
+SLEPC_objects = K_stored_in_a_slepc_matrix.o K_shell_matrix.o K_stored_in_a_nest_matrix.o \
                 K_multiply_by_V_slepc.o K_multiply_by_V_transpose_slepc.o
 #endif
 #if defined _PAR_IO

--- a/src/bse/K_diago_driver.F
+++ b/src/bse/K_diago_driver.F
@@ -182,9 +182,24 @@ subroutine K_diago_driver(iq,W,X_static)
      if(l_slepc) then
        ! 1. Here we will define a PetscShell matrix and define the matrix-vector multiplication
        ! using the K_multiply_by_V function used in the Haydock method
-       if (.not.BSS_slepc_matrix) call K_shell_matrix(i_BS_mat,slepc_mat)
+       if (BSS_slepc_matrix=="shell") then 
+         call K_shell_matrix(i_BS_mat,slepc_mat)
        ! 2. Here we create a distributed PETSC matrix from the BS_blks
-       if (     BSS_slepc_matrix) call K_stored_in_a_slepc_matrix(i_BS_mat,slepc_mat)
+       else if (BSS_slepc_matrix=="explicit") then
+         if (BS_K_coupling) then
+           ! 2.1. With memory optimization using nest matrix (only possible for the coupling case)      
+           call K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
+         else
+           ! 2.2. Explicit PETSc matrix for the rest of the cases      
+           call K_stored_in_a_slepc_matrix(i_BS_mat,slepc_mat)
+         endif
+       ! 2.3 No optimization of memory for the coupling case (debug)
+       else if (BSS_slepc_matrix=="explicit-debug") then
+         call K_stored_in_a_slepc_matrix(i_BS_mat,slepc_mat)
+       ! Default option is to use PetscShell
+       else 
+         call K_shell_matrix(i_BS_mat,slepc_mat)
+       endif        
      endif
 #endif
      !
@@ -420,8 +435,8 @@ subroutine K_diago_driver(iq,W,X_static)
      !
      call parser('BSSEnTarget',l_target_energy)
      !
-     if (     BSS_slepc_matrix)  call msg( 's', '[SLEPC] Faster alogorithm but BSE matrix diuplicated over MPI tasks')
-     if (.not.BSS_slepc_matrix)  call msg( 's', '[SLEPC] Slower alogorithm but BSE matrix distributed over MPI tasks')
+     if (BSS_slepc_matrix=='explicit'.or.BSS_slepc_matrix=='explicit-debug') call msg( 's', '[SLEPC] Faster alogorithm but BSE matrix duplicated over MPI tasks')
+     if (BSS_slepc_matrix=='shell')  call msg( 's', '[SLEPC] Slower alogorithm but BSE matrix distributed over MPI tasks')
      !
      ! Number of states for partial diagonalization
      !================================================
@@ -450,7 +465,7 @@ subroutine K_diago_driver(iq,W,X_static)
    !
    subroutine K_slepc_local_free()
      !
-     if (.not.BSS_slepc_matrix) then
+     if (BSS_slepc_matrix=='shell') then
        call BS_HAYVEC_free(Slepc_v%Vi)
        call BS_HAYVEC_free(Slepc_v%Vo)
        deallocate(Slepc_v%Vi)

--- a/src/bse/K_diago_driver.F
+++ b/src/bse/K_diago_driver.F
@@ -46,9 +46,9 @@ subroutine K_diago_driver(iq,W,X_static)
  use slepcepsdef
  use petscmatdef
  !
- use BS_solvers,     ONLY:BSS_slepc_matrix,Slepc_v,BS_HAYVEC_free
+ use BS_solvers,     ONLY:BSS_slepc_matrix_format,Slepc_v,BS_HAYVEC_free
 #endif
- use BS,             ONLY:l_BS_kerr,l_BS_magnons,l_BS_photolum
+ use BS,             ONLY:l_BS_kerr,l_BS_magnons,l_BS_photolum,l_BS_ares_from_res
  use MAGNONS,        ONLY:BSS_MAGN_free
  use PHOTOLUM,       ONLY:BSS_PL_free
  !
@@ -182,11 +182,11 @@ subroutine K_diago_driver(iq,W,X_static)
      if(l_slepc) then
        ! 1. Here we will define a PetscShell matrix and define the matrix-vector multiplication
        ! using the K_multiply_by_V function used in the Haydock method
-       if (BSS_slepc_matrix=="shell") then 
+       if (BSS_slepc_matrix_format=="shell") then 
          call K_shell_matrix(i_BS_mat,slepc_mat)
        ! 2. Here we create a distributed PETSC matrix from the BS_blks
-       else if (BSS_slepc_matrix=="explicit") then
-         if (BS_K_coupling) then
+       else if (BSS_slepc_matrix_format=="explicit") then
+         if (BS_K_coupling.and.l_BS_ares_from_res) then
            ! 2.1. With memory optimization using nest matrix (only possible for the coupling case)      
            call K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
          else
@@ -194,7 +194,7 @@ subroutine K_diago_driver(iq,W,X_static)
            call K_stored_in_a_slepc_matrix(i_BS_mat,slepc_mat)
          endif
        ! 2.3 No optimization of memory for the coupling case (debug)
-       else if (BSS_slepc_matrix=="explicit-debug") then
+       else if (BSS_slepc_matrix_format=="explicit-debug") then
          call K_stored_in_a_slepc_matrix(i_BS_mat,slepc_mat)
        ! Default option is to use PetscShell
        else 
@@ -432,11 +432,12 @@ subroutine K_diago_driver(iq,W,X_static)
    subroutine K_slepc_local_init()
      !
      use com,           ONLY:msg
+     call msg( 'sr', '[SLEPC] BSS_slepc_matrix_format                          ',BSS_slepc_matrix_format)
      !
      call parser('BSSEnTarget',l_target_energy)
      !
-     if (BSS_slepc_matrix=='explicit'.or.BSS_slepc_matrix=='explicit-debug') call msg( 's', '[SLEPC] Faster alogorithm but BSE matrix duplicated over MPI tasks')
-     if (BSS_slepc_matrix=='shell')  call msg( 's', '[SLEPC] Slower alogorithm but BSE matrix distributed over MPI tasks')
+     if (BSS_slepc_matrix_format=='explicit'.or.BSS_slepc_matrix_format=='explicit-debug') call msg( 's', '[SLEPC] Faster alogorithm but BSE matrix duplicated over MPI tasks')
+     if (BSS_slepc_matrix_format=='shell')  call msg( 's', '[SLEPC] Slower alogorithm but BSE matrix distributed over MPI tasks')
      !
      ! Number of states for partial diagonalization
      !================================================
@@ -465,7 +466,7 @@ subroutine K_diago_driver(iq,W,X_static)
    !
    subroutine K_slepc_local_free()
      !
-     if (BSS_slepc_matrix=='shell') then
+     if (BSS_slepc_matrix_format=='shell') then
        call BS_HAYVEC_free(Slepc_v%Vi)
        call BS_HAYVEC_free(Slepc_v%Vo)
        deallocate(Slepc_v%Vi)

--- a/src/bse/K_driver_init.F
+++ b/src/bse/K_driver_init.F
@@ -12,7 +12,7 @@ subroutine K_driver_init(what,iq,Ken,Xk)
  use parser_m,     ONLY:parser
  use parallel_m,   ONLY:PARALLEL_default_mode
  use stderr,       ONLY:STRING_match,STRING_same
- use BS_solvers,   ONLY:BSS_eels_to_eps,BSS_mode,BSS_slepc_matrix,BSS_uses_DbGd,&
+ use BS_solvers,   ONLY:BSS_eels_to_eps,BSS_mode,BSS_slepc_matrix_format,BSS_uses_DbGd,&
 &                       BSS_slepc_double_grp
  use BS,           ONLY:BSE_L_kind,BSE_mode,BS_K_is_ALDA,BS_dip_size,l_BSE_minimize_memory,BS_perturbative_SOC,&
 &                       BS_perturbative_SOC,l_BS_magnons,l_BS_photolum,&
@@ -173,7 +173,7 @@ subroutine K_driver_init(what,iq,Ken,Xk)
 #if defined _SLEPC && !defined _NL
  !
  ! Special case, slepc with distributed matrix need to explicitly compute the anti-resonant block
- l_slepc_special = index(BSS_mode,'s')/=0 .and. BS_K_coupling .and. (BSS_slepc_matrix=="shell")
+ l_slepc_special = index(BSS_mode,'s')/=0 .and. BS_K_coupling .and. (BSS_slepc_matrix_format=="shell")
  !
  ! The doubling is activated unless explicily imposed by input since slepc
  ! with shells requires the extended K_multiply_by_V for the non hermitian algorithm

--- a/src/bse/K_driver_init.F
+++ b/src/bse/K_driver_init.F
@@ -169,13 +169,11 @@ subroutine K_driver_init(what,iq,Ken,Xk)
  !
  ! SLEPC
  !=======
- ! Here we will have two options to initialize the slepc matrix:
- call parser('BSSSlepcMatrix',BSS_slepc_matrix)
  !
 #if defined _SLEPC && !defined _NL
  !
  ! Special case, slepc with distributed matrix need to explicitly compute the anti-resonant block
- l_slepc_special = index(BSS_mode,'s')/=0 .and. BS_K_coupling .and. (.not.BSS_slepc_matrix)
+ l_slepc_special = index(BSS_mode,'s')/=0 .and. BS_K_coupling .and. (BSS_slepc_matrix=="shell")
  !
  ! The doubling is activated unless explicily imposed by input since slepc
  ! with shells requires the extended K_multiply_by_V for the non hermitian algorithm

--- a/src/bse/K_stored_in_a_nest_matrix.F
+++ b/src/bse/K_stored_in_a_nest_matrix.F
@@ -25,7 +25,7 @@
 module shellmat_module
 #include <petsc/finclude/petscmat.h>
   use petscmat
-  Mat::A,B
+  Mat::R,C
 end module shellmat_module
 
 subroutine ignore_petsc_error_handler(comm,line,fun,file,n,p,mess,ctx,ierr)
@@ -44,8 +44,13 @@ end subroutine ignore_petsc_error_handler
 
 subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
 !
-! K is stored in a PETSc nest matrix, taking advantage of the four block structure
 ! BS_K_coupling and l_BS_ares_from_res are assumed TRUE
+!
+! K is stored in a PETSc nest matrix, taking advantage of the four block
+! structure of the matrix in this case:
+!
+! | R     C  |
+! |-C^*  -R^T|
 !
 #include <petsc/finclude/petscsys.h>
 #include <petsc/finclude/petscvec.h>
@@ -69,7 +74,7 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
   !
   integer, intent(in)  :: i_BS_mat
   Mat,     intent(out) :: slepc_mat
-  Mat                  :: AT,BHT
+  Mat                  :: RT,CHT
   Mat                  :: matArray(4)
   !
   integer     :: i_c,i_r,i_Tk,i_Tp,i_B,H_shift(2)
@@ -79,10 +84,10 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
   PetscInt            :: itwo
   PetscErrorCode      :: ierr
   !
-  external AT_mat_mult,BHT_mat_mult,& 
-           AT_mat_mult_transpose,BHT_mat_mult_transpose,&
-           AT_mat_mult_hermitian_transpose,BHT_mat_mult_hermitian_transpose,&
-           AT_get_diagonal,BHT_get_diagonal,&
+  external RT_mat_mult,CHT_mat_mult,& 
+           RT_mat_mult_transpose,CHT_mat_mult_transpose,&
+           RT_mat_mult_hermitian_transpose,CHT_mat_mult_hermitian_transpose,&
+           RT_get_diagonal,CHT_get_diagonal,&
            ignore_petsc_error_handler
   !
   SL_H_dim=BS_H_dim
@@ -90,29 +95,29 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
   !
   ! Allocate the explicit submatrices of the nest matrix
   !
-  call MatCreate(PETSC_COMM_WORLD,A,ierr)
-  call MatSetSizes(A,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,ierr)
-  call MatSetType(A,MATMPIDENSE,ierr)
+  call MatCreate(PETSC_COMM_WORLD,R,ierr)
+  call MatSetSizes(R,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,ierr)
+  call MatSetType(R,MATMPIDENSE,ierr)
   if (have_cuda) then
 #ifdef PETSC_HAVE_CUDA
-  call MatSetType(A,MATDENSECUDA,ierr)
-  call MatSetVecType(A,VECCUDA,ierr)
+  call MatSetType(R,MATDENSECUDA,ierr)
+  call MatSetVecType(R,VECCUDA,ierr)
 #endif
   endif
-  call MatSetFromOptions(A,ierr)
-  call MatSetUp(A,ierr)
+  call MatSetFromOptions(R,ierr)
+  call MatSetUp(R,ierr)
   !
-  call MatCreate(PETSC_COMM_WORLD,B,ierr)
-  call MatSetSizes(B,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,ierr)
-  call MatSetType(B,MATMPIDENSE,ierr)
+  call MatCreate(PETSC_COMM_WORLD,C,ierr)
+  call MatSetSizes(C,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,ierr)
+  call MatSetType(C,MATMPIDENSE,ierr)
   if (have_cuda) then
 #ifdef PETSC_HAVE_CUDA
-  call MatSetType(B,MATDENSECUDA,ierr)
-  call MatSetVecType(B,VECCUDA,ierr)
+  call MatSetType(C,MATDENSECUDA,ierr)
+  call MatSetVecType(C,VECCUDA,ierr)
 #endif
   endif
-  call MatSetFromOptions(B,ierr)
-  call MatSetUp(B,ierr)
+  call MatSetFromOptions(C,ierr)
+  call MatSetUp(C,ierr)
   !
   ! Fill the values of the explicit submatrices of the nest matrix
   !
@@ -152,14 +157,14 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
         !
         select case(BS_blk(i_B)%mode)
         case("R")
-           call MatSetValue( A, H_pos(1), H_pos(2),       Mij , INSERT_VALUES, ierr )
+           call MatSetValue( R, H_pos(1), H_pos(2),       Mij , INSERT_VALUES, ierr )
            ! The resonant block is hermitian
-           call MatSetValue( A, H_pos(2), H_pos(1),   Mij_star, INSERT_VALUES, ierr )
+           call MatSetValue( R, H_pos(2), H_pos(1),   Mij_star, INSERT_VALUES, ierr )
         case("C")
-           call MatSetValue( B, H_pos(1), H_pos(2),       Mij , INSERT_VALUES, ierr )
+           call MatSetValue( C, H_pos(1), H_pos(2),       Mij , INSERT_VALUES, ierr )
            ! Anti-coupling from coupling: the whole BSE matrix is Pseudo-HErmitian
            ! The coupling block and the anti-coupling block are symmetric
-           call MatSetValue( B, H_pos(2), H_pos(1),       Mij , INSERT_VALUES, ierr )
+           call MatSetValue( C, H_pos(2), H_pos(1),       Mij , INSERT_VALUES, ierr )
         end select
         !
       enddo
@@ -168,45 +173,45 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
     !
   enddo
   !
- call MatAssemblyBegin(A,MAT_FINAL_ASSEMBLY,ierr)
- call MatAssemblyEnd(A,MAT_FINAL_ASSEMBLY,ierr)
- call MatAssemblyBegin(B,MAT_FINAL_ASSEMBLY,ierr)
- call MatAssemblyEnd(B,MAT_FINAL_ASSEMBLY,ierr)
+ call MatAssemblyBegin(R,MAT_FINAL_ASSEMBLY,ierr)
+ call MatAssemblyEnd(R,MAT_FINAL_ASSEMBLY,ierr)
+ call MatAssemblyBegin(C,MAT_FINAL_ASSEMBLY,ierr)
+ call MatAssemblyEnd(C,MAT_FINAL_ASSEMBLY,ierr)
  !
  ! Create the two shell submatrices and define the required operations
  !
- call MatCreateShell(PETSC_COMM_WORLD,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,0,AT,ierr)
+ call MatCreateShell(PETSC_COMM_WORLD,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,0,RT,ierr)
  if (have_cuda) then
 #ifdef PETSC_HAVE_CUDA
- call MatSetVecType(AT,VECCUDA,ierr)
+ call MatSetVecType(RT,VECCUDA,ierr)
 #endif
  endif
- call MatShellSetOperation(AT,MATOP_GET_DIAGONAL,AT_get_diagonal,ierr)
- call MatShellSetOperation(AT,MATOP_MULT,AT_mat_mult,ierr)
- call MatShellSetOperation(AT,MATOP_MULT_TRANSPOSE,AT_mat_mult_transpose,ierr)
+ call MatShellSetOperation(RT,MATOP_GET_DIAGONAL,RT_get_diagonal,ierr)
+ call MatShellSetOperation(RT,MATOP_MULT,RT_mat_mult,ierr)
+ call MatShellSetOperation(RT,MATOP_MULT_TRANSPOSE,RT_mat_mult_transpose,ierr)
  call PetscPushErrorHandler(ignore_petsc_error_handler,PETSC_NULL_INTEGER,ierr)
- call MatShellSetOperation(AT,MATOP_MULT_HERMITIAN_TRANSPOSE,AT_mat_mult_hermitian_transpose,ierr)
+ call MatShellSetOperation(RT,MATOP_MULT_HERMITIAN_TRANSPOSE,RT_mat_mult_hermitian_transpose,ierr)
  call PetscPopErrorHandler(ierr)
  !
- call MatCreateShell(PETSC_COMM_WORLD,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,0,BHT,ierr)
+ call MatCreateShell(PETSC_COMM_WORLD,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,0,CHT,ierr)
  if (have_cuda) then
 #ifdef PETSC_HAVE_CUDA
- call MatSetVecType(BHT,VECCUDA,ierr)
+ call MatSetVecType(CHT,VECCUDA,ierr)
 #endif
  endif
- call MatShellSetOperation(BHT,MATOP_GET_DIAGONAL,BHT_get_diagonal,ierr)
- call MatShellSetOperation(BHT,MATOP_MULT,BHT_mat_mult,ierr)
- call MatShellSetOperation(BHT,MATOP_MULT_TRANSPOSE,BHT_mat_mult_transpose,ierr)
+ call MatShellSetOperation(CHT,MATOP_GET_DIAGONAL,CHT_get_diagonal,ierr)
+ call MatShellSetOperation(CHT,MATOP_MULT,CHT_mat_mult,ierr)
+ call MatShellSetOperation(CHT,MATOP_MULT_TRANSPOSE,CHT_mat_mult_transpose,ierr)
  call PetscPushErrorHandler(ignore_petsc_error_handler,PETSC_NULL_INTEGER,ierr)
- call MatShellSetOperation(BHT,MATOP_MULT_HERMITIAN_TRANSPOSE,BHT_mat_mult_hermitian_transpose,ierr)
+ call MatShellSetOperation(CHT,MATOP_MULT_HERMITIAN_TRANSPOSE,CHT_mat_mult_hermitian_transpose,ierr)
  call PetscPopErrorHandler(ierr)
  !
  ! Build the nest matrix
  !
- matArray(1) = A
- matArray(2) = B
- matArray(3) = BHT
- matArray(4) = AT
+ matArray(1) = R
+ matArray(2) = C
+ matArray(3) = CHT
+ matArray(4) = RT
  itwo = 2
  call MatCreateNest(PETSC_COMM_WORLD,itwo,PETSC_NULL_INTEGER,itwo,PETSC_NULL_INTEGER,matArray,slepc_mat,ierr)
  if (have_cuda) then
@@ -217,46 +222,46 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
  !
 end subroutine K_stored_in_a_nest_matrix
 
-subroutine AT_mat_mult(M,X,F,ierr)
+subroutine RT_mat_mult(M,X,F,ierr)
   use shellmat_module
   implicit none
   Mat     M
   Vec     X,F
   PetscScalar mone
   PetscErrorCode ierr
-  call MatMultTranspose(A,X,F,ierr)
+  call MatMultTranspose(R,X,F,ierr)
   mone = -1.0
   call VecScale(F,mone,ierr)
   return
-end subroutine AT_mat_mult
+end subroutine RT_mat_mult
 
-subroutine BHT_mat_mult(M,X,F,ierr)
+subroutine CHT_mat_mult(M,X,F,ierr)
   use shellmat_module
   implicit none
   Mat     M
   Vec     X,F
   PetscScalar mone
   PetscErrorCode ierr
-  call MatMultHermitianTranspose(B,X,F,ierr)
+  call MatMultHermitianTranspose(C,X,F,ierr)
   mone = -1.0
   call VecScale(F,mone,ierr)
   return
-end subroutine BHT_mat_mult
+end subroutine CHT_mat_mult
 
-subroutine AT_mat_mult_transpose(M,X,F,ierr)
+subroutine RT_mat_mult_transpose(M,X,F,ierr)
   use shellmat_module
   implicit none
   Mat     M
   Vec     X,F
   PetscScalar mone
   PetscErrorCode ierr
-  call MatMult(A,X,F,ierr)
+  call MatMult(R,X,F,ierr)
   mone = -1.0
   call VecScale(F,mone,ierr)
   return
-end subroutine AT_mat_mult_transpose
+end subroutine RT_mat_mult_transpose
 
-subroutine BHT_mat_mult_transpose(M,X,F,ierr)
+subroutine CHT_mat_mult_transpose(M,X,F,ierr)
   use shellmat_module
   implicit none
   Mat     M
@@ -266,15 +271,15 @@ subroutine BHT_mat_mult_transpose(M,X,F,ierr)
   call VecDuplicate(X,X_conjugate,ierr)
   call VecCopy(X,X_conjugate,ierr)
   call VecConjugate(X_conjugate,ierr)
-  call MatMult(B,X_conjugate,F,ierr)
+  call MatMult(C,X_conjugate,F,ierr)
   mone = -1.0
   call VecConjugate(F,ierr)
   call VecScale(F,mone,ierr)
   call VecDestroy(X_conjugate,ierr)
   return
-end subroutine BHT_mat_mult_transpose
+end subroutine CHT_mat_mult_transpose
 
-subroutine AT_mat_mult_hermitian_transpose(M,X,F,ierr)
+subroutine RT_mat_mult_hermitian_transpose(M,X,F,ierr)
   use shellmat_module
   implicit none
   Mat     M
@@ -284,49 +289,49 @@ subroutine AT_mat_mult_hermitian_transpose(M,X,F,ierr)
   call VecDuplicate(X,X_conjugate,ierr)
   call VecCopy(X,X_conjugate,ierr)
   call VecConjugate(X_conjugate,ierr)
-  call MatMult(A,X_conjugate,F,ierr)
+  call MatMult(R,X_conjugate,F,ierr)
   mone = -1.0
   call VecConjugate(F,ierr)
   call VecScale(F,mone,ierr)
   call VecDestroy(X_conjugate,ierr)
   return
-end subroutine AT_mat_mult_hermitian_transpose
+end subroutine RT_mat_mult_hermitian_transpose
 
-subroutine BHT_mat_mult_hermitian_transpose(M,X,F,ierr)
+subroutine CHT_mat_mult_hermitian_transpose(M,X,F,ierr)
   use shellmat_module
   implicit none
   Mat     M
   Vec     X,F
   PetscScalar mone
   PetscErrorCode ierr
-  call MatMult(B,X,F,ierr)
+  call MatMult(C,X,F,ierr)
   mone = -1.0
   call VecScale(F,mone,ierr)
   return
-end subroutine BHT_mat_mult_hermitian_transpose
+end subroutine CHT_mat_mult_hermitian_transpose
 
-subroutine AT_get_diagonal(M,D)
+subroutine RT_get_diagonal(M,D)
   use shellmat_module
   implicit none
   Mat     M
   Vec     D
   PetscScalar mone
   PetscErrorCode ierr
-  call MatGetDiagonal(A,D,ierr)
+  call MatGetDiagonal(R,D,ierr)
   mone = -1.0
   call VecScale(D,mone,ierr)
   return
-end subroutine AT_get_diagonal
+end subroutine RT_get_diagonal
 
-subroutine BHT_get_diagonal(M,D)
+subroutine CHT_get_diagonal(M,D)
   use shellmat_module
   implicit none
   Mat     M
   Vec     D
   PetscScalar mone
   PetscErrorCode ierr
-  call MatGetDiagonal(B,D,ierr)
+  call MatGetDiagonal(C,D,ierr)
   mone = -1.0
   call VecScale(D,mone,ierr)
   return
-end subroutine BHT_get_diagonal
+end subroutine CHT_get_diagonal

--- a/src/bse/K_stored_in_a_nest_matrix.F
+++ b/src/bse/K_stored_in_a_nest_matrix.F
@@ -1,0 +1,243 @@
+!
+!        Copyright (C) 2000-2023 the YAMBO team
+!              http://www.yambo-code.org
+!
+! Authors (see AUTHORS file for details): 
+! 
+! This file is distributed under the terms of the GNU 
+! General Public License. You can redistribute it and/or 
+! modify it under the terms of the GNU General Public 
+! License as published by the Free Software Foundation; 
+! either version 2, or (at your option) any later version.
+!
+! This program is distributed in the hope that it will 
+! be useful, but WITHOUT ANY WARRANTY; without even the 
+! implied warranty of MERCHANTABILITY or FITNESS FOR A 
+! PARTICULAR PURPOSE.  See the GNU General Public License 
+! for more details.
+!
+! You should have received a copy of the GNU General Public 
+! License along with this program; if not, write to the Free 
+! Software Foundation, Inc., 59 Temple Place - Suite 330,Boston, 
+! MA 02111-1307, USA or visit http://www.gnu.org/copyleft/gpl.txt.
+!
+
+module shellmat_module
+#include <petsc/finclude/petscmat.h>
+  use petscmat
+  Mat::A,B
+end module shellmat_module
+
+subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
+! K is stored in a PETSc nest matrix, taking advantage of the four block structure
+#include <petsc/finclude/petscsys.h>
+#include <petsc/finclude/petscvec.h>
+#include <petsc/finclude/petscmat.h>
+#include <petsc/finclude/petscvec.h>
+#include <slepc/finclude/slepcsys.h>
+#include <slepc/finclude/slepceps.h>
+!
+  use pars,           ONLY:cI,cONE
+  use BS,             ONLY:BS_K_dim,BS_H_dim,BS_blk,n_BS_blks,BS_K_coupling,&
+  &                        BS_res_ares_n_mat,l_BS_ares_from_res
+  use BS_solvers,     ONLY:BSS_eh_E,BSS_eh_W,BSS_perturbative_width
+  use com,            ONLY:msg
+  !
+  use petscmat
+  use slepceps
+  use slepcepsdef
+  use petscmatdef
+  use shellmat_module
+  !
+  implicit none
+  !
+  integer, intent(in)  :: i_BS_mat
+  Mat,     intent(out) :: slepc_mat
+  Mat                  :: AT,BHT
+  Mat                  :: matArray(4)
+  !
+  integer     :: i_c,i_r,i_Tk,i_Tp,i_B,H_shift(2)
+  PetscScalar         :: Mij,Mij_star
+  PetscScalar         :: mone
+  PetscInt            :: H_pos(2),SL_K_dim(2),SL_H_dim
+  PetscInt            :: itwo
+  PetscErrorCode      :: ierr
+  character (len = 70) :: str_num_block
+  !
+  external AT_mat_mult, BHT_mat_mult, AT_mat_mult_transpose, BHT_mat_mult_transpose
+  !
+  call msg( 'nsr', '[SLEPC] Matrix is nest')
+  !
+  if(     BS_K_coupling) SL_H_dim=BS_H_dim
+  if(.not.BS_K_coupling) SL_H_dim=BS_K_dim(i_BS_mat)
+  SL_K_dim=BS_K_dim
+  !
+  ! Allocate the slepc Matrix
+  !
+  call MatCreate(PETSC_COMM_WORLD,A,ierr)
+  call MatSetSizes(A,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,ierr)
+  call MatSetType(A, MATMPIDENSE,ierr)
+  call MatSetFromOptions(A,ierr)
+  call MatSetUp(A,ierr)
+  !
+  call MatCreate(PETSC_COMM_WORLD,B,ierr)
+  call MatSetSizes(B,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,ierr)
+  call MatSetType(B, MATMPIDENSE,ierr)
+  call MatSetFromOptions(B,ierr)
+  call MatSetUp(B,ierr)
+  !
+  ! Filling of the slepc_mat
+  !
+  do i_B=1,n_BS_blks
+    i_Tk  =BS_blk(i_B)%iT_k
+    i_Tp  =BS_blk(i_B)%iT_p
+    !
+    if (i_BS_mat/=BS_blk(i_B)%ira_k .and. BS_res_ares_n_mat==2) cycle
+    !
+    H_shift=0
+    if(BS_blk(i_B)%mode=="C") H_shift(2)=BS_K_dim(1)
+    if(BS_blk(i_B)%mode=="A") H_shift(:)=BS_K_dim(1)
+    !
+    do i_r=1,BS_blk(i_B)%size(1)
+      !
+      H_pos(1)=BS_blk(i_B)%coordinate(1)+i_r-2
+      !
+      do i_c=1,BS_blk(i_B)%size(2)
+        !
+        H_pos(2)=BS_blk(i_B)%coordinate(2)+i_c-2
+        !
+        ! Then the upper triangle of each block and direct symmetrization
+        !
+        if (H_pos(1)+H_shift(1)>H_pos(2)+H_shift(2)) cycle
+        if (l_BS_ares_from_res.and.H_pos(1)>H_pos(2)) cycle
+        !
+        Mij     =      BS_blk(i_B)%mat(i_r,i_c)
+        Mij_star= real(BS_blk(i_B)%mat(i_r,i_c))-cI*aimag(BS_blk(i_B)%mat(i_r,i_c))
+        !
+        ! Add energies to the diagonal
+        !
+        if(H_pos(1)+H_shift(1)==H_pos(2)+H_shift(2)) then
+          Mij     =real(Mij)     +BSS_eh_E(H_pos(1)+H_shift(1)+1)*cONE
+          Mij_star=real(Mij_star)+BSS_eh_E(H_pos(1)+H_shift(1)+1)*cONE
+          if (allocated(BSS_eh_W).and..not.BSS_perturbative_width) then
+            Mij     =Mij            +cI*BSS_eh_W(H_pos(1)+H_shift(1)+1)
+            Mij_star=Mij_star       -cI*BSS_eh_W(H_pos(1)+H_shift(1)+1)
+          endif
+        endif
+        !
+        select case(BS_blk(i_B)%mode)
+        case("R")
+           call MatSetValue( A, H_pos(1), H_pos(2),       Mij , INSERT_VALUES, ierr )
+           ! The resonant block is hermitian
+           call MatSetValue( A, H_pos(2), H_pos(1),   Mij_star, INSERT_VALUES, ierr )
+         if (l_BS_ares_from_res.and.BS_K_coupling) then
+           ! The anti-resonant block is A=-R*
+           !call MatSetValue( slepc_mat, H_pos(1)+SL_K_dim(1), H_pos(2)+SL_K_dim(1), -Mij_star, INSERT_VALUES, ierr )
+           ! The anti-resonant block is hermitian
+           !call MatSetValue( slepc_mat, H_pos(2)+SL_K_dim(1), H_pos(1)+SL_K_dim(1),      -Mij, INSERT_VALUES, ierr )
+         endif
+        case("C")
+           call MatSetValue( B, H_pos(1), H_pos(2),       Mij , INSERT_VALUES, ierr )
+           ! Anti-coupling from coupling: the whole BSE matrix is Pseudo-HErmitian
+           if (l_BS_ares_from_res) then
+             ! The coupling block and the anti-coupling block are symmetric
+             call MatSetValue( B, H_pos(2), H_pos(1),       Mij , INSERT_VALUES, ierr )
+           endif
+        case("A")
+         ! The anti-resonant block is hermitial
+         if(BS_res_ares_n_mat==1) then
+           !call MatSetValue( slepc_mat, H_pos(1)+SL_K_dim(1), H_pos(2)+SL_K_dim(1),       Mij , INSERT_VALUES, ierr )
+           !call MatSetValue( slepc_mat, H_pos(2)+SL_K_dim(1), H_pos(1)+SL_K_dim(1),  Mij_star , INSERT_VALUES, ierr )
+         else
+           !call MatSetValue( slepc_mat, H_pos(1), H_pos(2),       Mij , INSERT_VALUES, ierr )
+           !call MatSetValue( slepc_mat, H_pos(2), H_pos(1),  Mij_star , INSERT_VALUES, ierr )
+         endif
+        case("Q")
+           !call MatSetValue( slepc_mat, H_pos(1)+SL_K_dim(1), H_pos(2),       Mij , INSERT_VALUES, ierr )
+           ! Coupling from anti-coupling: the whole BSE matrix is Pseudo-HErmitian
+           !call MatSetValue( slepc_mat, H_pos(2), H_pos(1)+SL_K_dim(1), -Mij_star , INSERT_VALUES, ierr )
+        end select
+        !
+      enddo
+      !
+    enddo
+    !
+  enddo
+  !
+ call MatAssemblyBegin(A,MAT_FINAL_ASSEMBLY,ierr)
+ call MatAssemblyEnd(A,MAT_FINAL_ASSEMBLY,ierr)
+ call MatAssemblyBegin(B,MAT_FINAL_ASSEMBLY,ierr)
+ call MatAssemblyEnd(B,MAT_FINAL_ASSEMBLY,ierr)
+ !
+ call MatCreateShell(PETSC_COMM_WORLD,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,0,AT,ierr)
+ call MatShellSetOperation(AT,MATOP_MULT,AT_mat_mult,ierr)
+ call MatShellSetOperation(AT,MATOP_MULT_TRANSPOSE,AT_mat_mult_transpose,ierr)
+ !
+ call MatCreateShell(PETSC_COMM_WORLD,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,0,BHT,ierr)
+ call MatShellSetOperation(BHT,MATOP_MULT,BHT_mat_mult,ierr)
+ call MatShellSetOperation(BHT,MATOP_MULT_TRANSPOSE,BHT_mat_mult_transpose,ierr)
+ !
+ matArray(1) = A
+ matArray(2) = B
+ matArray(3) = BHT
+ matArray(4) = AT
+ itwo = 2
+ call MatCreateNest(PETSC_COMM_WORLD,itwo,PETSC_NULL_INTEGER,itwo,PETSC_NULL_INTEGER,matArray,slepc_mat,ierr)
+ !
+end subroutine K_stored_in_a_nest_matrix
+
+subroutine AT_mat_mult(M,X,F,ierr)
+  use shellmat_module
+  implicit none
+  Mat     M
+  Vec     X,F
+  PetscScalar mone
+  PetscErrorCode ierr
+  call MatMultTranspose(A,X,F,ierr)
+  mone = -1.0
+  call VecScale(F,mone,ierr)
+  return
+end subroutine AT_mat_mult
+
+subroutine BHT_mat_mult(M,X,F,ierr)
+  use shellmat_module
+  implicit none
+  Mat     M
+  Vec     X,F
+  PetscScalar mone
+  PetscErrorCode ierr
+  call MatMultHermitianTranspose(B,X,F,ierr)
+  mone = -1.0
+  call VecScale(F,mone,ierr)
+  return
+end subroutine BHT_mat_mult
+
+subroutine AT_mat_mult_transpose(M,X,F,ierr)
+  use shellmat_module
+  implicit none
+  Mat     M
+  Vec     X,F
+  PetscScalar mone
+  PetscErrorCode ierr
+  call MatMult(A,X,F,ierr)
+  mone = -1.0
+  call VecScale(F,mone,ierr)
+  return
+end subroutine AT_mat_mult_transpose
+
+subroutine BHT_mat_mult_transpose(M,X,F,ierr)
+  use shellmat_module
+  implicit none
+  Mat     M
+  Vec     X,F
+  PetscScalar mone
+  PetscErrorCode ierr
+  call VecConjugate(X,ierr)
+  call MatMult(B,X,F,ierr)
+  mone = -1.0
+  call VecConjugate(F,ierr)
+  call VecScale(F,mone,ierr)
+  call VecConjugate(X,ierr)
+  return
+end subroutine BHT_mat_mult_transpose
+

--- a/src/bse/K_stored_in_a_nest_matrix.F
+++ b/src/bse/K_stored_in_a_nest_matrix.F
@@ -29,7 +29,10 @@ module shellmat_module
 end module shellmat_module
 
 subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
+!
 ! K is stored in a PETSc nest matrix, taking advantage of the four block structure
+! BS_K_coupling and l_BS_ares_from_res are assumed TRUE
+!
 #include <petsc/finclude/petscsys.h>
 #include <petsc/finclude/petscvec.h>
 #include <petsc/finclude/petscmat.h>
@@ -38,10 +41,8 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
 #include <slepc/finclude/slepceps.h>
 !
   use pars,           ONLY:cI,cONE
-  use BS,             ONLY:BS_K_dim,BS_H_dim,BS_blk,n_BS_blks,BS_K_coupling,&
-  &                        BS_res_ares_n_mat,l_BS_ares_from_res
+  use BS,             ONLY:BS_K_dim,BS_H_dim,BS_blk,n_BS_blks
   use BS_solvers,     ONLY:BSS_eh_E,BSS_eh_W,BSS_perturbative_width
-  use com,            ONLY:msg
   !
   use petscmat
   use slepceps
@@ -62,17 +63,13 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
   PetscInt            :: H_pos(2),SL_K_dim(2),SL_H_dim
   PetscInt            :: itwo
   PetscErrorCode      :: ierr
-  character (len = 70) :: str_num_block
   !
   external AT_mat_mult, BHT_mat_mult, AT_mat_mult_transpose, BHT_mat_mult_transpose
   !
-  call msg( 'nsr', '[SLEPC] Matrix is nest')
-  !
-  if(     BS_K_coupling) SL_H_dim=BS_H_dim
-  if(.not.BS_K_coupling) SL_H_dim=BS_K_dim(i_BS_mat)
+  SL_H_dim=BS_H_dim
   SL_K_dim=BS_K_dim
   !
-  ! Allocate the slepc Matrix
+  ! Allocate the explicit submatrices of the nest matrix
   !
   call MatCreate(PETSC_COMM_WORLD,A,ierr)
   call MatSetSizes(A,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,ierr)
@@ -86,17 +83,14 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
   call MatSetFromOptions(B,ierr)
   call MatSetUp(B,ierr)
   !
-  ! Filling of the slepc_mat
+  ! Fill the values of the explicit submatrices of the nest matrix
   !
   do i_B=1,n_BS_blks
     i_Tk  =BS_blk(i_B)%iT_k
     i_Tp  =BS_blk(i_B)%iT_p
     !
-    if (i_BS_mat/=BS_blk(i_B)%ira_k .and. BS_res_ares_n_mat==2) cycle
-    !
     H_shift=0
     if(BS_blk(i_B)%mode=="C") H_shift(2)=BS_K_dim(1)
-    if(BS_blk(i_B)%mode=="A") H_shift(:)=BS_K_dim(1)
     !
     do i_r=1,BS_blk(i_B)%size(1)
       !
@@ -109,7 +103,7 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
         ! Then the upper triangle of each block and direct symmetrization
         !
         if (H_pos(1)+H_shift(1)>H_pos(2)+H_shift(2)) cycle
-        if (l_BS_ares_from_res.and.H_pos(1)>H_pos(2)) cycle
+        if (H_pos(1)>H_pos(2)) cycle
         !
         Mij     =      BS_blk(i_B)%mat(i_r,i_c)
         Mij_star= real(BS_blk(i_B)%mat(i_r,i_c))-cI*aimag(BS_blk(i_B)%mat(i_r,i_c))
@@ -130,32 +124,11 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
            call MatSetValue( A, H_pos(1), H_pos(2),       Mij , INSERT_VALUES, ierr )
            ! The resonant block is hermitian
            call MatSetValue( A, H_pos(2), H_pos(1),   Mij_star, INSERT_VALUES, ierr )
-         if (l_BS_ares_from_res.and.BS_K_coupling) then
-           ! The anti-resonant block is A=-R*
-           !call MatSetValue( slepc_mat, H_pos(1)+SL_K_dim(1), H_pos(2)+SL_K_dim(1), -Mij_star, INSERT_VALUES, ierr )
-           ! The anti-resonant block is hermitian
-           !call MatSetValue( slepc_mat, H_pos(2)+SL_K_dim(1), H_pos(1)+SL_K_dim(1),      -Mij, INSERT_VALUES, ierr )
-         endif
         case("C")
            call MatSetValue( B, H_pos(1), H_pos(2),       Mij , INSERT_VALUES, ierr )
            ! Anti-coupling from coupling: the whole BSE matrix is Pseudo-HErmitian
-           if (l_BS_ares_from_res) then
-             ! The coupling block and the anti-coupling block are symmetric
-             call MatSetValue( B, H_pos(2), H_pos(1),       Mij , INSERT_VALUES, ierr )
-           endif
-        case("A")
-         ! The anti-resonant block is hermitial
-         if(BS_res_ares_n_mat==1) then
-           !call MatSetValue( slepc_mat, H_pos(1)+SL_K_dim(1), H_pos(2)+SL_K_dim(1),       Mij , INSERT_VALUES, ierr )
-           !call MatSetValue( slepc_mat, H_pos(2)+SL_K_dim(1), H_pos(1)+SL_K_dim(1),  Mij_star , INSERT_VALUES, ierr )
-         else
-           !call MatSetValue( slepc_mat, H_pos(1), H_pos(2),       Mij , INSERT_VALUES, ierr )
-           !call MatSetValue( slepc_mat, H_pos(2), H_pos(1),  Mij_star , INSERT_VALUES, ierr )
-         endif
-        case("Q")
-           !call MatSetValue( slepc_mat, H_pos(1)+SL_K_dim(1), H_pos(2),       Mij , INSERT_VALUES, ierr )
-           ! Coupling from anti-coupling: the whole BSE matrix is Pseudo-HErmitian
-           !call MatSetValue( slepc_mat, H_pos(2), H_pos(1)+SL_K_dim(1), -Mij_star , INSERT_VALUES, ierr )
+           ! The coupling block and the anti-coupling block are symmetric
+           call MatSetValue( B, H_pos(2), H_pos(1),       Mij , INSERT_VALUES, ierr )
         end select
         !
       enddo
@@ -169,6 +142,8 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
  call MatAssemblyBegin(B,MAT_FINAL_ASSEMBLY,ierr)
  call MatAssemblyEnd(B,MAT_FINAL_ASSEMBLY,ierr)
  !
+ ! Create the two shell submatrices and define the required operations
+ !
  call MatCreateShell(PETSC_COMM_WORLD,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,0,AT,ierr)
  call MatShellSetOperation(AT,MATOP_MULT,AT_mat_mult,ierr)
  call MatShellSetOperation(AT,MATOP_MULT_TRANSPOSE,AT_mat_mult_transpose,ierr)
@@ -176,6 +151,8 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
  call MatCreateShell(PETSC_COMM_WORLD,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,0,BHT,ierr)
  call MatShellSetOperation(BHT,MATOP_MULT,BHT_mat_mult,ierr)
  call MatShellSetOperation(BHT,MATOP_MULT_TRANSPOSE,BHT_mat_mult_transpose,ierr)
+ !
+ ! Build the nest matrix
  !
  matArray(1) = A
  matArray(2) = B

--- a/src/bse/K_stored_in_a_nest_matrix.F
+++ b/src/bse/K_stored_in_a_nest_matrix.F
@@ -82,6 +82,7 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
   external AT_mat_mult,BHT_mat_mult,& 
            AT_mat_mult_transpose,BHT_mat_mult_transpose,&
            AT_mat_mult_hermitian_transpose,BHT_mat_mult_hermitian_transpose,&
+           AT_get_diagonal,BHT_get_diagonal,&
            ignore_petsc_error_handler
   !
   SL_H_dim=BS_H_dim
@@ -180,6 +181,7 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
  call MatSetVecType(AT,VECCUDA,ierr)
 #endif
  endif
+ call MatShellSetOperation(AT,MATOP_GET_DIAGONAL,AT_get_diagonal,ierr)
  call MatShellSetOperation(AT,MATOP_MULT,AT_mat_mult,ierr)
  call MatShellSetOperation(AT,MATOP_MULT_TRANSPOSE,AT_mat_mult_transpose,ierr)
  call PetscPushErrorHandler(ignore_petsc_error_handler,PETSC_NULL_INTEGER,ierr)
@@ -192,6 +194,7 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
  call MatSetVecType(BHT,VECCUDA,ierr)
 #endif
  endif
+ call MatShellSetOperation(BHT,MATOP_GET_DIAGONAL,BHT_get_diagonal,ierr)
  call MatShellSetOperation(BHT,MATOP_MULT,BHT_mat_mult,ierr)
  call MatShellSetOperation(BHT,MATOP_MULT_TRANSPOSE,BHT_mat_mult_transpose,ierr)
  call PetscPushErrorHandler(ignore_petsc_error_handler,PETSC_NULL_INTEGER,ierr)
@@ -301,3 +304,29 @@ subroutine BHT_mat_mult_hermitian_transpose(M,X,F,ierr)
   call VecScale(F,mone,ierr)
   return
 end subroutine BHT_mat_mult_hermitian_transpose
+
+subroutine AT_get_diagonal(M,D)
+  use shellmat_module
+  implicit none
+  Mat     M
+  Vec     D
+  PetscScalar mone
+  PetscErrorCode ierr
+  call MatGetDiagonal(A,D,ierr)
+  mone = -1.0
+  call VecScale(D,mone,ierr)
+  return
+end subroutine AT_get_diagonal
+
+subroutine BHT_get_diagonal(M,D)
+  use shellmat_module
+  implicit none
+  Mat     M
+  Vec     D
+  PetscScalar mone
+  PetscErrorCode ierr
+  call MatGetDiagonal(B,D,ierr)
+  mone = -1.0
+  call VecScale(D,mone,ierr)
+  return
+end subroutine BHT_get_diagonal

--- a/src/bse/K_stored_in_a_nest_matrix.F
+++ b/src/bse/K_stored_in_a_nest_matrix.F
@@ -28,6 +28,20 @@ module shellmat_module
   Mat::A,B
 end module shellmat_module
 
+subroutine ignore_petsc_error_handler(comm,line,fun,file,n,p,mess,ctx,ierr)
+!
+! Handler to ignore error if MatMultHermitianTranspose cannot be set.
+! This operation is only available for shell matrices in PETSc from v.3.21
+! Setting MatMultTranspose is enough, but it is preferable to set both.
+!
+  use petscsysdef
+  integer line,n,p
+  PetscInt ctx 
+  PetscErrorCode ierr
+  MPI_Comm comm
+  character*(*) fun,file,mess
+end subroutine ignore_petsc_error_handler
+
 subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
 !
 ! K is stored in a PETSc nest matrix, taking advantage of the four block structure
@@ -65,7 +79,10 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
   PetscInt            :: itwo
   PetscErrorCode      :: ierr
   !
-  external AT_mat_mult, BHT_mat_mult, AT_mat_mult_transpose, BHT_mat_mult_transpose
+  external AT_mat_mult,BHT_mat_mult,& 
+           AT_mat_mult_transpose,BHT_mat_mult_transpose,&
+           AT_mat_mult_hermitian_transpose,BHT_mat_mult_hermitian_transpose,&
+           ignore_petsc_error_handler
   !
   SL_H_dim=BS_H_dim
   SL_K_dim=BS_K_dim
@@ -165,6 +182,9 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
  endif
  call MatShellSetOperation(AT,MATOP_MULT,AT_mat_mult,ierr)
  call MatShellSetOperation(AT,MATOP_MULT_TRANSPOSE,AT_mat_mult_transpose,ierr)
+ call PetscPushErrorHandler(ignore_petsc_error_handler,PETSC_NULL_INTEGER,ierr)
+ call MatShellSetOperation(AT,MATOP_MULT_HERMITIAN_TRANSPOSE,AT_mat_mult_hermitian_transpose,ierr)
+ call PetscPopErrorHandler(ierr)
  !
  call MatCreateShell(PETSC_COMM_WORLD,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,0,BHT,ierr)
  if (have_cuda) then
@@ -174,6 +194,9 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
  endif
  call MatShellSetOperation(BHT,MATOP_MULT,BHT_mat_mult,ierr)
  call MatShellSetOperation(BHT,MATOP_MULT_TRANSPOSE,BHT_mat_mult_transpose,ierr)
+ call PetscPushErrorHandler(ignore_petsc_error_handler,PETSC_NULL_INTEGER,ierr)
+ call MatShellSetOperation(BHT,MATOP_MULT_HERMITIAN_TRANSPOSE,BHT_mat_mult_hermitian_transpose,ierr)
+ call PetscPopErrorHandler(ierr)
  !
  ! Build the nest matrix
  !
@@ -234,15 +257,47 @@ subroutine BHT_mat_mult_transpose(M,X,F,ierr)
   use shellmat_module
   implicit none
   Mat     M
-  Vec     X,F
+  Vec     X,X_conjugate,F
   PetscScalar mone
   PetscErrorCode ierr
-  call VecConjugate(X,ierr)
-  call MatMult(B,X,F,ierr)
+  call VecDuplicate(X,X_conjugate,ierr)
+  call VecCopy(X,X_conjugate,ierr)
+  call VecConjugate(X_conjugate,ierr)
+  call MatMult(B,X_conjugate,F,ierr)
   mone = -1.0
   call VecConjugate(F,ierr)
   call VecScale(F,mone,ierr)
-  call VecConjugate(X,ierr)
+  call VecDestroy(X_conjugate,ierr)
   return
 end subroutine BHT_mat_mult_transpose
 
+subroutine AT_mat_mult_hermitian_transpose(M,X,F,ierr)
+  use shellmat_module
+  implicit none
+  Mat     M
+  Vec     X,X_conjugate,F
+  PetscScalar mone
+  PetscErrorCode ierr
+  call VecDuplicate(X,X_conjugate,ierr)
+  call VecCopy(X,X_conjugate,ierr)
+  call VecConjugate(X_conjugate,ierr)
+  call MatMult(A,X_conjugate,F,ierr)
+  mone = -1.0
+  call VecConjugate(F,ierr)
+  call VecScale(F,mone,ierr)
+  call VecDestroy(X_conjugate,ierr)
+  return
+end subroutine AT_mat_mult_hermitian_transpose
+
+subroutine BHT_mat_mult_hermitian_transpose(M,X,F,ierr)
+  use shellmat_module
+  implicit none
+  Mat     M
+  Vec     X,F
+  PetscScalar mone
+  PetscErrorCode ierr
+  call MatMult(B,X,F,ierr)
+  mone = -1.0
+  call VecScale(F,mone,ierr)
+  return
+end subroutine BHT_mat_mult_hermitian_transpose

--- a/src/bse/K_stored_in_a_nest_matrix.F
+++ b/src/bse/K_stored_in_a_nest_matrix.F
@@ -43,6 +43,7 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
   use pars,           ONLY:cI,cONE
   use BS,             ONLY:BS_K_dim,BS_H_dim,BS_blk,n_BS_blks
   use BS_solvers,     ONLY:BSS_eh_E,BSS_eh_W,BSS_perturbative_width
+  use cuda_m,         ONLY:have_cuda
   !
   use petscmat
   use slepceps
@@ -73,13 +74,25 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
   !
   call MatCreate(PETSC_COMM_WORLD,A,ierr)
   call MatSetSizes(A,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,ierr)
-  call MatSetType(A, MATMPIDENSE,ierr)
+  call MatSetType(A,MATMPIDENSE,ierr)
+  if (have_cuda) then
+#ifdef PETSC_HAVE_CUDA
+  call MatSetType(A,MATDENSECUDA,ierr)
+  call MatSetVecType(A,VECCUDA,ierr)
+#endif
+  endif
   call MatSetFromOptions(A,ierr)
   call MatSetUp(A,ierr)
   !
   call MatCreate(PETSC_COMM_WORLD,B,ierr)
   call MatSetSizes(B,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,ierr)
-  call MatSetType(B, MATMPIDENSE,ierr)
+  call MatSetType(B,MATMPIDENSE,ierr)
+  if (have_cuda) then
+#ifdef PETSC_HAVE_CUDA
+  call MatSetType(B,MATDENSECUDA,ierr)
+  call MatSetVecType(B,VECCUDA,ierr)
+#endif
+  endif
   call MatSetFromOptions(B,ierr)
   call MatSetUp(B,ierr)
   !
@@ -145,10 +158,20 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
  ! Create the two shell submatrices and define the required operations
  !
  call MatCreateShell(PETSC_COMM_WORLD,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,0,AT,ierr)
+ if (have_cuda) then
+#ifdef PETSC_HAVE_CUDA
+ call MatSetVecType(AT,VECCUDA,ierr)
+#endif
+ endif
  call MatShellSetOperation(AT,MATOP_MULT,AT_mat_mult,ierr)
  call MatShellSetOperation(AT,MATOP_MULT_TRANSPOSE,AT_mat_mult_transpose,ierr)
  !
  call MatCreateShell(PETSC_COMM_WORLD,PETSC_DECIDE,PETSC_DECIDE,SL_H_dim/2,SL_H_dim/2,0,BHT,ierr)
+ if (have_cuda) then
+#ifdef PETSC_HAVE_CUDA
+ call MatSetVecType(BHT,VECCUDA,ierr)
+#endif
+ endif
  call MatShellSetOperation(BHT,MATOP_MULT,BHT_mat_mult,ierr)
  call MatShellSetOperation(BHT,MATOP_MULT_TRANSPOSE,BHT_mat_mult_transpose,ierr)
  !
@@ -160,6 +183,11 @@ subroutine K_stored_in_a_nest_matrix(i_BS_mat,slepc_mat)
  matArray(4) = AT
  itwo = 2
  call MatCreateNest(PETSC_COMM_WORLD,itwo,PETSC_NULL_INTEGER,itwo,PETSC_NULL_INTEGER,matArray,slepc_mat,ierr)
+ if (have_cuda) then
+#ifdef PETSC_HAVE_CUDA
+ call MatSetVecType(slepc_mat,VECCUDA,ierr)
+#endif
+ endif
  !
 end subroutine K_stored_in_a_nest_matrix
 

--- a/src/interface/INIT_activate.F
+++ b/src/interface/INIT_activate.F
@@ -279,7 +279,7 @@ subroutine INIT_activate()
    if (index(BSS_mode,'h')/=0)  call initactivate(1,'BSHayTrs BSHayTer BSHayItrIO BSHayItrMAX')
    if (index(BSS_mode,'s')/=0)  then
      call initactivate(1,'BSSNEig BSSEnTarget BSSSlepcApproach BSSSlepcPrecondition BSSSlepcExtraction')
-     call initactivate(1,'BSSSlepcMaxIt BSSSlepcNCV BSSSlepcTol BSSSlepcMatrix')
+     call initactivate(1,'BSSSlepcMaxIt BSSSlepcNCV BSSSlepcTol BSSSlepcMatrixFormat')
    endif
    !
    ! Special project dependent variables

--- a/src/interface/INIT_load.F
+++ b/src/interface/INIT_load.F
@@ -39,7 +39,7 @@ subroutine INIT_load(defs,en,q,k,X,Xw,Dip)
 &                        BSS_Wd,K_INV_EPS,K_INV_PL,BSS_n_eig,Haydock_iterMAX
 #if defined _SLEPC && !defined _NL
  use BS_solvers,    ONLY:BSS_slepc_target_E,BSS_slepc_extraction,BSS_slepc_ncv,BSS_slepc_tol,BSS_slepc_maxit,&
- &                       BSS_slepc_precondition,BSS_slepc_approach,BSS_slepc_matrix
+ &                       BSS_slepc_precondition,BSS_slepc_approach,BSS_slepc_matrix_format
 #endif
  use TDDFT,         ONLY:FXC_n_g_corr,FXC_per_memstps,FXC_LRC_alpha,FXC_LRC_beta, &
 &                        FXC_SVD_digits,FXC_PF_alpha,ALDA_cut_scheme
@@ -326,8 +326,7 @@ subroutine INIT_load(defs,en,q,k,X,Xw,Dip)
  call it(defs,'BSSSlepcExtraction','[SLEPC] Extraction technique (ritz|harmonic)',BSS_slepc_extraction,verb_level=V_resp)
  call it(defs,'BSSSlepcNCV',   '[SLEPC] Dimension of the subspace',BSS_slepc_ncv,verb_level=V_resp)
  call it(defs,'BSSSlepcTol',   '[SLEPC] Tolerance for the iterative solver',BSS_slepc_tol,verb_level=V_resp)
- !call it('f',defs,'BSSSlepcMatrix','[SLEPC] Store slepc matrix, faster but more memory consuming',verb_level=V_resp)
- call it(defs,'BSSSlepcMatrix','[SLEPC] Matrix type (shell|explicit|explicit-debug)',BSS_slepc_matrix,verb_level=V_resp)
+ call it(defs,'BSSSlepcMatrixFormat','[SLEPC] Matrix type (shell|explicit|explicit-debug)',BSS_slepc_matrix_format,verb_level=V_resp)
 #endif
 #if !defined _SC
  call it('f',defs,'ALLGexx', '[BSS] Force the use use all RL vectors for the exchange part',verb_level=V_resp)

--- a/src/interface/INIT_load.F
+++ b/src/interface/INIT_load.F
@@ -39,7 +39,7 @@ subroutine INIT_load(defs,en,q,k,X,Xw,Dip)
 &                        BSS_Wd,K_INV_EPS,K_INV_PL,BSS_n_eig,Haydock_iterMAX
 #if defined _SLEPC && !defined _NL
  use BS_solvers,    ONLY:BSS_slepc_target_E,BSS_slepc_extraction,BSS_slepc_ncv,BSS_slepc_tol,BSS_slepc_maxit,&
- &                       BSS_slepc_precondition,BSS_slepc_approach
+ &                       BSS_slepc_precondition,BSS_slepc_approach,BSS_slepc_matrix
 #endif
  use TDDFT,         ONLY:FXC_n_g_corr,FXC_per_memstps,FXC_LRC_alpha,FXC_LRC_beta, &
 &                        FXC_SVD_digits,FXC_PF_alpha,ALDA_cut_scheme
@@ -326,7 +326,8 @@ subroutine INIT_load(defs,en,q,k,X,Xw,Dip)
  call it(defs,'BSSSlepcExtraction','[SLEPC] Extraction technique (ritz|harmonic)',BSS_slepc_extraction,verb_level=V_resp)
  call it(defs,'BSSSlepcNCV',   '[SLEPC] Dimension of the subspace',BSS_slepc_ncv,verb_level=V_resp)
  call it(defs,'BSSSlepcTol',   '[SLEPC] Tolerance for the iterative solver',BSS_slepc_tol,verb_level=V_resp)
- call it('f',defs,'BSSSlepcMatrix','[SLEPC] Store slepc matrix, faster but more memory consuming',verb_level=V_resp)
+ !call it('f',defs,'BSSSlepcMatrix','[SLEPC] Store slepc matrix, faster but more memory consuming',verb_level=V_resp)
+ call it(defs,'BSSSlepcMatrix','[SLEPC] Matrix type (shell|explicit|explicit-debug)',BSS_slepc_matrix,verb_level=V_resp)
 #endif
 #if !defined _SC
  call it('f',defs,'ALLGexx', '[BSS] Force the use use all RL vectors for the exchange part',verb_level=V_resp)

--- a/src/modules/SET_defaults.F
+++ b/src/modules/SET_defaults.F
@@ -54,7 +54,7 @@ subroutine SET_defaults(INSTR,IND,OD,COM_DIR)
  use descriptors,ONLY:IO_desc_reset
 #if defined _SLEPC && !defined _NL
  use BS_solvers, ONLY:BSS_slepc_extraction,BSS_slepc_ncv,BSS_slepc_tol,BSS_slepc_target_E,BSS_slepc_maxit,&
- &                    BSS_slepc_precondition,BSS_slepc_approach
+ &                    BSS_slepc_precondition,BSS_slepc_approach,BSS_slepc_matrix
 #endif
  use BS,         ONLY:BS_n_g_W,BS_eh_en,BS_identifier,BS_q,BS_eh_win,MAX_BSK_LIN_size,&
 &                     BS_K_dim,BS_not_const_eh_f,BSK_mode,l_BSE_kernel_complete,&
@@ -466,6 +466,7 @@ subroutine SET_defaults(INSTR,IND,OD,COM_DIR)
  MAX_BSK_LIN_size=45000*45000 ! 46341 is the sqare root of the maximum integer in IP: 2147483647
  !
 #if defined _SLEPC && !defined _NL
+ BSS_slepc_matrix='shell'
  BSS_slepc_approach='none'
  BSS_slepc_precondition='none'
  BSS_slepc_extraction='ritz'

--- a/src/modules/SET_defaults.F
+++ b/src/modules/SET_defaults.F
@@ -54,7 +54,7 @@ subroutine SET_defaults(INSTR,IND,OD,COM_DIR)
  use descriptors,ONLY:IO_desc_reset
 #if defined _SLEPC && !defined _NL
  use BS_solvers, ONLY:BSS_slepc_extraction,BSS_slepc_ncv,BSS_slepc_tol,BSS_slepc_target_E,BSS_slepc_maxit,&
- &                    BSS_slepc_precondition,BSS_slepc_approach,BSS_slepc_matrix
+ &                    BSS_slepc_precondition,BSS_slepc_approach,BSS_slepc_matrix_format
 #endif
  use BS,         ONLY:BS_n_g_W,BS_eh_en,BS_identifier,BS_q,BS_eh_win,MAX_BSK_LIN_size,&
 &                     BS_K_dim,BS_not_const_eh_f,BSK_mode,l_BSE_kernel_complete,&
@@ -466,7 +466,7 @@ subroutine SET_defaults(INSTR,IND,OD,COM_DIR)
  MAX_BSK_LIN_size=45000*45000 ! 46341 is the sqare root of the maximum integer in IP: 2147483647
  !
 #if defined _SLEPC && !defined _NL
- BSS_slepc_matrix='shell'
+ BSS_slepc_matrix_format='shell'
  BSS_slepc_approach='none'
  BSS_slepc_precondition='none'
  BSS_slepc_extraction='ritz'

--- a/src/modules/mod_BS_solvers.F
+++ b/src/modules/mod_BS_solvers.F
@@ -88,15 +88,15 @@ module BS_solvers
  !
  ! Solvers (Slepc)
  !=========
- character(schlen):: BSS_slepc_approach     !choose slepc approach ("Krylov-Schur","Generalized-Davidson","Jacob-Davidson")
- character(schlen):: BSS_slepc_precondition !choose slepc eigenvalue precondition method (none,bcgs+jacobi)
- character(schlen):: BSS_slepc_extraction   !choose slepc eigenvalue extraction method (ritz,harmonic)
- integer          :: BSS_slepc_ncv        !dimension of the subspace
- integer          :: BSS_slepc_maxit      !maximum number of iterations
- real(SP)         :: BSS_slepc_tol        !tolerance for the iterative solver
- real(SP)         :: BSS_slepc_target_E   !find eigenvalues close to this energy
- character(schlen):: BSS_slepc_matrix     !matrix type ("shell","explicit","explicit-debug")
- logical          :: BSS_slepc_double_grp !duplicate the number of groups for slepc shells solver
+ character(schlen):: BSS_slepc_approach      !choose slepc approach ("Krylov-Schur","Generalized-Davidson","Jacob-Davidson")
+ character(schlen):: BSS_slepc_precondition  !choose slepc eigenvalue precondition method (none,bcgs+jacobi)
+ character(schlen):: BSS_slepc_extraction    !choose slepc eigenvalue extraction method (ritz,harmonic)
+ integer          :: BSS_slepc_ncv           !dimension of the subspace
+ integer          :: BSS_slepc_maxit         !maximum number of iterations
+ real(SP)         :: BSS_slepc_tol           !tolerance for the iterative solver
+ real(SP)         :: BSS_slepc_target_E      !find eigenvalues close to this energy
+ character(schlen):: BSS_slepc_matrix_format !matrix type ("shell","explicit","explicit-debug")
+ logical          :: BSS_slepc_double_grp    !duplicate the number of groups for slepc shells solver
  !
  ! Solvers (Inversion)
  !=========

--- a/src/modules/mod_BS_solvers.F
+++ b/src/modules/mod_BS_solvers.F
@@ -95,7 +95,7 @@ module BS_solvers
  integer          :: BSS_slepc_maxit      !maximum number of iterations
  real(SP)         :: BSS_slepc_tol        !tolerance for the iterative solver
  real(SP)         :: BSS_slepc_target_E   !find eigenvalues close to this energy
- logical          :: BSS_slepc_matrix     !use a shell matrix for slepc
+ character(schlen):: BSS_slepc_matrix     !matrix type ("shell","explicit","explicit-debug")
  logical          :: BSS_slepc_double_grp !duplicate the number of groups for slepc shells solver
  !
  ! Solvers (Inversion)


### PR DESCRIPTION
Joint work with @joseeroman

Introduces a new matrix format for the SLEPc solver, which optimizes the performance for the BSE with coupling. This format can be used only if `BS_K_coupling` and `l_BS_ares_from_res` are `TRUE`. 

The new format uses a PETSc nest matrix to take advantage of the structure of the matrix in this case:
```
| R      C  |
|-C^*   -R^T|
```
The top blocks are stored explicitly, and the bottom blocks are shell matrices, reducing the memory required to store the matrix by approximately half.

Previous `BSSSlepcMatrix` logical option is changed to `BSSSlepcMatrixFormat`, with three options:
- `'shell'`: Shell matrix 
- `'explicit'`: If it is posible, it will use the new format with a nest matrix to store the four blocks
- `'explicit-debug'`: It will always use the old version of the explicit matrix, without the nest storage

If Yambo and PETSc are configured with CUDA, matrix operations with the nest format will be performed in GPU.

