### PR TITLE
Fix bug in str_trimm PARSER.c

### DIFF
--- a/src/parser/PARSER.c
+++ b/src/parser/PARSER.c
@@ -33,9 +33,12 @@ static char *str_trim(char *in)
 
 	for(c=s; isspace(*c); c++);
 	for(; *c != '\0'; *s++=*c++);
-	for(s--; isspace(*s); s--);
-	*(s+1) = '\0';
-
+	if (s != in)
+	{
+		for(s--; isspace(*s); s--);
+		*(s+1) = '\0';
+	}
+	else *s = '\0';
 	return in;
 }
 


### PR DESCRIPTION
This along with https://github.com/yambo-code/Ydriver/pull/2 will fix memory bugs in the parser. Now running ```-fsanitize=address``` should not crash as mentioned in the issue https://github.com/yambo-code/yambo/issues/111

Additionally, this should fix other bugs when parsing (for ex segmentation faults when giving large number of bands/ kpoints in ypp band interpolation or building QP databases) 