### PR TITLE
Reduce overhead

### DIFF
--- a/src/Ymodules/mod_X.F
+++ b/src/Ymodules/mod_X.F
@@ -118,7 +118,9 @@ module X_m
  type(PAR_matrix), target      :: X_par_lower_triangle
  logical                       :: X_lower_triangle_matrix_in_use=.FALSE.
  integer                       :: X_rows(2) = 0
+ !DEV_ACC declare device_resident(X_rows)
  integer                       :: X_cols(2) = 0
+ !DEV_ACC declare device_resident(X_cols)
  complex(SP), allocatable, target :: X_mat(:,:,:)
  complex(SP), allocatable, target DEV_ATTR :: X_mat_d(:,:,:)
  !

--- a/src/allocations/X_ALLOC_parallel.F
+++ b/src/allocations/X_ALLOC_parallel.F
@@ -46,7 +46,9 @@ subroutine X_ALLOC_parallel(X_par,NG,NW,mode)
  endif
  !
  X_rows = X_par%rows
+ !DEV_ACC update device(X_rows)
  X_cols = X_par%cols
+ !DEV_ACC update device(X_cols)
  !
  if (l_XUP.and..not.X_FILL_UP_matrix_only.and.X_par%INTER_comm%n_CPU>1) then
    !


### PR DESCRIPTION
declare device directive added to allocate small variables on the GPU for the whole lifetime of the program
This removes some data movements in low level routines
Tested with nvhpc/23.1 (works without present)