### PR TITLE
fix[openacc,data]: zeroing Xo_res on GPU

### DIFF
--- a/src/pol_function/X_irredux_residuals.F
+++ b/src/pol_function/X_irredux_residuals.F
@@ -66,7 +66,9 @@ subroutine X_irredux_residuals(Xen,Xk,X,Dip,i_cg,iq,Xo_res,Xo_scatt,work,lwork)
  isave     = 0
  n_poles   = sum(bare_grid_N(1:i_cg-1))
  Z_        = cONE
+ !DEV_ACC kernels
  Xo_res    = cZERO
+ !DEV_ACC end kernels
  call devxlib_memset_d(Xo_res,cZERO)
  !
  ngrho     = Xo_scatt%ngrho


### PR DESCRIPTION
This is related to issue https://github.com/yambo-code/yambo/issues/153#issue-2655961491

Opened in DRAFT because I expect the same issue with OpenMP offload, and I am not sure the zeroing is actually needed.