### PR TITLE
fix compitation and bugs

### DIFF
--- a/lib/archive/package.list
+++ b/lib/archive/package.list
@@ -26,7 +26,7 @@ keep_hdf5=no
 #
 # package versions
 #
-version_Ydiago=0.3.1
+version_Ydiago=0.4.0
 version_iotk=y1.2.2
 version_netcdf=4.9.0
 version_netcdff=4.6.0

--- a/lib/ydiago/make_ydiago.inc.in
+++ b/lib/ydiago/make_ydiago.inc.in
@@ -12,7 +12,7 @@ FC               = @FC@
 AR               = @AR@
 CPP              = @CPP@ 
 
-CFLAGS       	 = @CFLAGS@  #-g -fsanitize=address -fno-omit-frame-pointer 
+CFLAGS       	 = -O3 #@CFLAGS@  #-g -fsanitize=address -fno-omit-frame-pointer 
 YAMBO_FLAGS   	 = @def_mpi@ @def_scalapack@ @def_compiler@ @def_dp@ @def_openmp@ @def_gpu@ @def_elpa@
 ELPA_INC         = @ELPA_INCS@ @LIBCUDA_INCS@ @GPU_INCS@ @LIBROCM_INCS@
 
@@ -40,7 +40,7 @@ ELPA_INC         = @ELPA_INCS@ @LIBCUDA_INCS@ @GPU_INCS@ @LIBROCM_INCS@
 
 
 make             = @MAKE@
-CFLAGS           = @CFLAGS@ $(IFLAGS)
+#CFLAGS           = @CFLAGS@ $(IFLAGS)
 CPP              = @CPP@
 FPP              = @FPP@
 CPPFLAGS         = @CPPFLAGS@ $(IFLAGS)

--- a/src/bse/K_diagonalize.F
+++ b/src/bse/K_diagonalize.F
@@ -65,7 +65,7 @@ subroutine K_diagonalize(i_BS_mat, BS_energies, BS_VR, &
   ! Local variables
   type(c_ptr)                        :: mpicxt, diago_mat, evecs
   integer                            :: nProcs, my_rank
-  integer(YDIAGO_INT)                :: SL_H_dim, ProcX, ProcY, elpa_nthreads
+  integer(YDIAGO_INT)                :: SL_H_dim, ProcX, ProcY, elpa_nthreads, mpi_comm
   integer(ERROR_INT)                 :: error_diago ! diagonalization error code
   integer                            :: ierr !! mpi error code 
   integer(YDIAGO_INT)                :: neig_found, i_c, i_r, blacs_blk_size 
@@ -80,6 +80,9 @@ subroutine K_diagonalize(i_BS_mat, BS_energies, BS_VR, &
   logical                            :: run_gpu = .false.
   complex(YDIAGO_CMPLX), target, allocatable :: eig_vals(:)
   !
+  integer(YDIAGO_INT), target        :: neigs_range_y(2)
+  real(YDIAGO_FLOAT), target         :: eigvals_range_y(2)
+  !
   ! Gpu support via ELPA.
   type(c_ptr)                             :: gpu_str = c_null_ptr
   character(kind=c_char, len=20), target  :: gpu_device_elpa
@@ -88,8 +91,18 @@ subroutine K_diagonalize(i_BS_mat, BS_energies, BS_VR, &
   integer                            :: evec_fac = 1
   ! evec_fac = 2 if bse_solver function was used to diagonalize else 1
 
-  if(present(neigs_range)) neigs_range_tmp = c_loc(neigs_range)
-  if(present(eigvals_range)) eigvals_range_tmp = c_loc(eigvals_range)
+  if(present(neigs_range)) then
+    neigs_range_y(1) = neigs_range(1) 
+    neigs_range_y(2) = neigs_range(2) 
+    neigs_range_tmp = c_loc(neigs_range_y)
+  end if
+  !!
+  if(present(eigvals_range)) then
+    eigvals_range_y(1) = eigvals_range(1) 
+    eigvals_range_y(2) = eigvals_range(2) 
+    eigvals_range_tmp = c_loc(eigvals_range_y)
+  end if
+  !!
   if(present(BS_VL)) compute_left_eigs = .true.
   if(present(solver_type)) solver_type_aux = solver_type
   if(present(elpasolver)) elpa_solver_aux = elpasolver
@@ -157,7 +170,9 @@ endif
   
   call msg("s","BLACS grid",(/ProcX,ProcY/))
 
-  mpicxt = BLACScxtInit_Fortran('R', MPI_COMM_WORLD, ProcX, ProcY)
+  mpi_comm = MPI_COMM_WORLD
+
+  mpicxt = BLACScxtInit_Fortran('R', mpi_comm, ProcX, ProcY)
   if (.not. c_associated(mpicxt)) then
     call error("Failed to initiate BLACS context")
   end if

--- a/src/bse/K_driver_init.F
+++ b/src/bse/K_driver_init.F
@@ -14,7 +14,8 @@ subroutine K_driver_init(what,iq,Ken,Xk)
  use stderr,       ONLY:STRING_match
  use BS_solvers,   ONLY:BSS_mode,BSS_slepc_matrix_format,BSS_uses_DbGd,&
 &                       BSS_slepc_double_grp,run_Slepc,BSS_mode,BSS_first_eig,       &
-&                       l_abs_prop_chi_bse,l_eels_can_be_computed,l_eels_from_inversion
+&                       l_abs_prop_chi_bse,l_eels_can_be_computed,l_eels_from_inversion,  &
+&                       BSS_ydiago_solver
  use BS,           ONLY:BSE_L_kind,BSE_mode,BS_K_is_ALDA,BS_dip_size,l_BSE_minimize_memory,BS_perturbative_SOC,&
 &                       BS_perturbative_SOC,l_BS_magnons,l_BS_photolum,&
 &                       BS_cpl_K_exchange,BS_n_g_exch,BS_res_K_exchange,BS_K_coupling,BS_res_ares_n_mat,&

--- a/src/interface/INIT_load.F
+++ b/src/interface/INIT_load.F
@@ -321,11 +321,11 @@ subroutine INIT_load(defs,en,q,k,X,Xw,Dip)
  call it('f',defs,'WehDiag', '[BSK] diagonal (G-space) the eh interaction',verb_level=V_resp)
  call it('f',defs,'WehCpl',  '[BSK] eh interaction included also in coupling')
  call it('f',defs,'WRbsWF',  '[BSS] Write to disk excitonic the WFs')
+ call it(defs,'BSSNEig',       '[SLEPC/DIAG] Number of eigenvalues to compute',BSS_n_eig)
+ call it(defs,'BSSFirstEig',  '[DIAGO] Index of the first eigenvalues to compute',BSS_first_eig)
 #if defined _SLEPC && !defined _NL
  call it(defs,'BSSSlepcApproach','[SLEPC] Approach ("Krylov-Schur","Generalized-Davidson","Jacobi-Davidson")',&
 &                                                                          BSS_slepc_approach,verb_level=V_resp)
- call it(defs,'BSSNEig',       '[SLEPC/DIAG] Number of eigenvalues to compute',BSS_n_eig)
- call it(defs,'BSSFirstEig',  '[DIAGO] Index of the first eigenvalues to compute',BSS_first_eig)
  call it(defs,'BSSEnTarget',   '[SLEPC] Target energy to find eigenvalues',BSS_slepc_target_E,E_unit)
  call it(defs,'BSSSlepcMaxIt', '[SLEPC] Maximum number of iterations',BSS_slepc_maxit)
  call it(defs,'BSSSlepcPrecondition','[SLEPC] Precondition technique (none|preonly+jacobi|bcgs+jacobi)',&


### PR DESCRIPTION
1) New ydiago solver for some performance improvements.
2) Fix compilation errors and pass correct types to ydiago library.


@sangallidavide 
I tried to play with the Matrix_transfer driver, I get segmentation faults, and even though I tried to fix it, it does not scale beyond 100 cpus, as it creates so many MPI send/recv requests and our cluster just gaveup. Unless, it is fixed, I personally prefer to stick with ydiago implemention as it is highly robust and can scale to 1000's of cpus and can handle any matrix that yambo can construct !

