### PR TITLE
Fix buffer overflow in options_ypp.c

### DIFF
--- a/include/driver/kind.h
+++ b/include/driver/kind.h
@@ -44,7 +44,7 @@ typedef struct options_struct
  int  short_opt;
  char *long_opt;
  char *short_desc;
- char long_desc[20][100];
+ char long_desc[20][128];
  char *bin;
  char *no_bin;
  char *yambo_string;


### PR DESCRIPTION
Fix buffer overflow caused in https://github.com/yambo-code/yambo/blob/master/src/driver/options_ypp.c#L192

Currently, ```long_desc``` can only have 99 characters. In options_ypp.c#L192, we feed more than 99 causing buffer overflow and buggy ```ypp``` program. I increased the ```long_desc``` size to 128 in ```kind.h```, to fit more characters

pushing it to master as it should be fixed asap (ypp crashing on my laptop).

