### PR TITLE
some fixes in 5.4 BS solvers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,7 +23,6 @@ ACTIVE DEVELOPERS
  * Riccardo Reho                   (RR)  	 (2022)
  * Giacomo Sesti                   (GS)  	 (2022)
  * Blanca Mellado Pinto            (BM)          (2023)
- * Nalabothula Muralidhar          (NM)          (2024)
 
 FORMER DEVELOPERS
 ==================
@@ -42,6 +41,7 @@ FORMER DEVELOPERS
  * Henrique Miranda                (HM)  	 (2016-2018)
  * Elena Molteni                   (EM)  	 (2019-2021)
  * Ignacio Martin Alliati          (IMA) 	 (2020-2024)
+ * Nalabothula Muralidhar          (NM)      (2024-2025)
 
 ACKNOWLEDGEMENTS
 =================

--- a/lib/slepc/Makefile.loc
+++ b/lib/slepc/Makefile.loc
@@ -16,7 +16,7 @@ TARBALL=$(tarball_slepc)
 include ../config/external_libs_commons.mk
 include ../config/external_libs_defs.mk
 #
-CONFFLAGS=--prefix="$(LIBPATH)"
+CONFFLAGS=--prefix=$(LIBPATH)
 #
 # MAIN target
 #
@@ -70,3 +70,4 @@ clean:
 
 clean_all: clean
 	@$(rm_the_lib)
+

--- a/src/bse/K_diago_driver.F
+++ b/src/bse/K_diago_driver.F
@@ -579,6 +579,8 @@ subroutine K_diago_driver(iq,W,X_static)
    !
    subroutine K_local_init()
      !
+     BSS_n_eig=BSS_n_eig_Input
+     !
      K_is_not_hermitian=BS_K_coupling.or.(allocated(BSS_eh_W).and..not.BSS_perturbative_width)
      !
 #if defined _SLEPC && !defined _NL


### PR DESCRIPTION
1) Allow partial diagonalization with ELPA/SLK. preferred over Slepc if more than 5% of eigenvectors are needed
2) fix Slepc internal compilation