### PR TITLE
Lkind check allows for irreducible exciton calculation

### DIFF
--- a/src/bse/K_driver_init.F
+++ b/src/bse/K_driver_init.F
@@ -165,8 +165,9 @@ subroutine K_driver_init(what,iq,Ken,Xk)
  !
  ! BSE_L_kind check
  !==============
- if (.not.STRING_match(BSE_L_kind,"bar").and..not.STRING_match(BSE_L_kind,"full")) &
- & call error('set Lkind = DEFAULT or BAR or FULL')
+ if
+(.not.STRING_match(BSE_L_kind,"bar").and..not.STRING_match(BSE_L_kind,"full").and..not.STRING_match(BSE_L_kind,"tilde")) &
+ & call error('set Lkind = DEFAULT or BAR or FULL or TILDE')
  !
  BS_K_is_ALDA=l_alda_fxc
  if (l_alda_fxc) then

--- a/src/bse/K_driver_init.F
+++ b/src/bse/K_driver_init.F
@@ -51,7 +51,19 @@ subroutine K_driver_init(what,iq,Ken,Xk)
  BS_res_ares_n_mat=1
  !
  ! default mode
- if(STRING_match(BSE_L_kind,"default")) BSE_L_kind="default-bar"
+ if (iq==1) then
+   ! Default is Lbar for optical absorption. Consequences:
+   ! 1. No LT splitting in 3D (use 'Lkind= full' for that)
+   ! 2. BSE Hamiltonian fully symmetric (no nonanalytic term)
+   if(STRING_match(BSE_L_kind,"default")) BSE_L_kind="default-bar"
+ endif
+ !
+ if (iq/=1) then
+   ! Default is Lfull as Lbar is NOT defined and gives WRONG results
+   ! BSE Hamiltonian is fully symmetric with Lfull
+   if(STRING_match(BSE_L_kind,"default")) BSE_L_kind="default-full"
+   if(STRING_match(BSE_L_kind,"bar")) call error("Lbar not defined at q/=0")
+endif
  !
  if (l_col_cut.and.what=="init") then
    ! We are here in 0D, 1D or 2D

--- a/src/bse/K_driver_init.F
+++ b/src/bse/K_driver_init.F
@@ -165,8 +165,9 @@ subroutine K_driver_init(what,iq,Ken,Xk)
  !
  ! BSE_L_kind check
  !==============
- if
-(.not.STRING_match(BSE_L_kind,"bar").and..not.STRING_match(BSE_L_kind,"full").and..not.STRING_match(BSE_L_kind,"tilde")) &
+ if    (.not.STRING_match(BSE_L_kind,"bar") & 
+ & .and..not.STRING_match(BSE_L_kind,"full") &
+ & .and..not.STRING_match(BSE_L_kind,"tilde")) &
  & call error('set Lkind = DEFAULT or BAR or FULL or TILDE')
  !
  BS_K_is_ALDA=l_alda_fxc


### PR DESCRIPTION
As discussed with Alberto, currently a check at line 166 of `K_driver_init` would not accept `Lkind='tilde'` as input option for irreducible exciton calculations, although this case is coded below at line 266 of the same file and also documented at input generation via `INIT_load`.

The change simply recognizes `Lkind='tilde'` as an option to switch off the exchange part of the BSE kernel. 

Also note that 
```
Lkind='tilde'
```

is equivalent - but more straightforward - to
```
Lkind='bar'
BSENGexx = 0 RL
```