### PR TITLE
Symmetrize X0(q->0)

### DIFF
--- a/src/bse/K_driver_init.F
+++ b/src/bse/K_driver_init.F
@@ -59,11 +59,12 @@ subroutine K_driver_init(what,iq,Ken,Xk)
  endif
  !
  if (iq/=1) then
-   ! Default is Lfull as Lbar is NOT defined and gives WRONG results
+   ! For finite momentum Lbar is NOT defined and gives WRONG results
    ! BSE Hamiltonian is fully symmetric with Lfull
-   if(STRING_match(BSE_L_kind,"default")) BSE_L_kind="default-full"
-   if(STRING_match(BSE_L_kind,"bar")) call error("Lbar not defined at q/=0")
-endif
+   if (.not. STRING_match(BSE_L_kind, "full")) &
+&   call warning('Lbar is defined only for q = 0. For q /= 0, it is always set to "full".')
+   BSE_L_kind="full"
+ endif
  !
  if (l_col_cut.and.what=="init") then
    ! We are here in 0D, 1D or 2D
@@ -77,18 +78,6 @@ endif
      ! directly remove the G=0 term
      call warning('Coulomb cutoff at q=0. Default/Suggested Lkind= bar')
      if (STRING_match(BSE_L_kind,"default")) BSE_L_kind="default-bar"
-   endif
-   if (iq/=1) then
-     ! We are here in 1D or 2D.
-     ! At q>0 there is L-T spliting in 1D or 2D
-     ! Lbar and Lfull give the same result only in the limit V->infinity
-     ! The above mentioned G=0 term is part of this effect.
-     ! Here we assume it would be better to include it, to be double checked
-     call warning('Coulomb cutoff at q>0. Default/Suggested Lkind= full')
-     if (STRING_match(BSE_L_kind,"default")) BSE_L_kind="default-full"
-     ! N.B.: One could compute the calculation without L-T slitting,
-     ! by removing such full line (2D) / plane (1D). Not coded at the moment.
-     ! I would define it as L="transverse"
    endif
  endif
  !

--- a/src/bse/K_driver_init.F
+++ b/src/bse/K_driver_init.F
@@ -63,7 +63,7 @@ subroutine K_driver_init(what,iq,Ken,Xk)
    ! BSE Hamiltonian is fully symmetric with Lfull
    if (.not. STRING_match(BSE_L_kind, "full")) &
 &   call warning('Lbar is defined only for q = 0. For q /= 0, it is always set to "full".')
-   BSE_L_kind="full"
+   BSE_L_kind="default-full"
  endif
  !
  if (l_col_cut.and.what=="init") then

--- a/src/bse/K_driver_init.F
+++ b/src/bse/K_driver_init.F
@@ -61,9 +61,10 @@ subroutine K_driver_init(what,iq,Ken,Xk)
  if (iq/=1) then
    ! For finite momentum Lbar is NOT defined and gives WRONG results
    ! BSE Hamiltonian is fully symmetric with Lfull
-   if (.not. STRING_match(BSE_L_kind, "full")) &
-&   call warning('Lbar is defined only for q = 0. For q /= 0, it is always set to "full".')
-   BSE_L_kind="default-full"
+   if (.not. STRING_match(BSE_L_kind, "full")) then
+    call warning('Lbar is defined only for q = 0. For q /= 0, it is always set to "full".')
+    BSE_L_kind="default-full"
+   endif
  endif
  !
  if (l_col_cut.and.what=="init") then

--- a/src/io_parallel/io_BS_PAR_free.F
+++ b/src/io_parallel/io_BS_PAR_free.F
@@ -42,7 +42,10 @@ subroutine io_BS_PAR_free(ID_head,ID,mode,l_kernel_complete)
    endif
  endif
  !
- if(.not.io_BS_K .and. trim(mode)=="full" )      return
+ if(.not.io_BS_K .and. trim(mode)=="full" ) then
+   call io_disconnect(ID)
+   return
+ endif
  !
  if(trim(mode)=="compressed_mat".or.trim(mode)=="full") call io_disconnect(ID)
  !

--- a/src/io_parallel/io_BS_header.F
+++ b/src/io_parallel/io_BS_header.F
@@ -76,6 +76,7 @@ integer function io_BS_header(iq,X,ID,mode)
  if (io_BS_header/=0.and.io_mode(ID)/=DUMP) then
    call io_elemental(ID,VAR="",VAR_SZ=0,MENU=1)
    call warning('Invalid dimensions found. BSE restart file '//trim(full_db_name)//' not accepted')
+   call io_disconnect(ID)
    return
  endif
  !

--- a/src/pol_function/X_dielectric_matrix.F
+++ b/src/pol_function/X_dielectric_matrix.F
@@ -348,6 +348,8 @@ integer function X_dielectric_matrix(Xen,Xk,q,X,Xw,Dip,SILENT_MODE,CHILD)
      !
      if (.not.l_rpa_IP) call X_redux(iq,"X"//trim(X_what),X_par(iq_mem),Xw,X)
      !
+     if (iq==1) call X_symmetrize_q0(X_par(iq_mem),X%ng,Xw)
+     !
      if (n_OPTICAL_dir_to_eval>1.and.iq_dir==1) call MATRIX_copy(X_par(iq_mem),X_par_average,.TRUE.)
      if (n_OPTICAL_dir_to_eval>1)               call X_AVERAGE_do_it("ACCUMULATE",X_par(iq_mem))
      !
@@ -486,3 +488,67 @@ integer function X_dielectric_matrix(Xen,Xk,q,X,Xw,Dip,SILENT_MODE,CHILD)
    end subroutine
    !
 end function
+
+subroutine X_symmetrize_q0(X_par, NG, Xw)
+  use pars,          ONLY: SP, DP, cZERO
+  use matrix,        ONLY: PAR_matrix
+  use frequency,     ONLY: w_samp
+  use D_lattice,     ONLY: nsym, i_time_rev
+  use R_lattice,     ONLY: g_rot
+  use parallel_int,  ONLY: PP_redux_wait
+  use com,           ONLY: msg
+
+  implicit none
+
+  type(PAR_matrix), intent(inout) :: X_par
+  integer,          intent(in)    :: NG
+  type(w_samp),     intent(in)    :: Xw
+
+  integer :: ig1, ig2, ig1_sym, ig2_sym, isym, iw
+  integer :: nsym_loop, ig1_loc
+  complex(SP), allocatable :: X_full(:,:,:)
+
+  if (nsym <= 1) return
+
+  call msg('r', 'Applying q->0 symmetries to the macroscopic dielectric matrix')
+
+  allocate(X_full(NG, NG, Xw%n_freqs))
+  X_full = cZERO
+  
+  if (X_par%nrows>0) X_full(X_par%rows(1):X_par%rows(2), 1:NG, :) = X_par%blc(1:X_par%nrows, 1:NG, :)
+  
+  call PP_redux_wait(X_full, COMM=X_par%INTER_comm%COMM)
+  
+  X_par%blc = cZERO
+  
+  do iw = 1, Xw%n_freqs
+     if (abs(Xw%p(iw)) < 1.e-5_SP) then
+        nsym_loop = nsym
+     else
+        nsym_loop = nsym / (i_time_rev + 1)
+     endif
+
+     do ig2 = 1, NG
+        do ig1_loc = 1, X_par%nrows
+           ig1 = ig1_loc + X_par%rows(1) - 1
+           do isym = 1, nsym_loop
+              ig1_sym = g_rot(ig1, isym)
+              ig2_sym = g_rot(ig2, isym)
+              
+              if (ig1_sym > 0 .and. ig1_sym <= NG .and. ig2_sym > 0 .and. ig2_sym <= NG) then
+                 if (isym > nsym / (i_time_rev + 1)) then
+                    X_par%blc(ig1_loc, ig2, iw) = X_par%blc(ig1_loc, ig2, iw) + &
+                         conjg(X_full(ig1_sym, ig2_sym, iw)) / real(nsym_loop, SP)
+                 else
+                    X_par%blc(ig1_loc, ig2, iw) = X_par%blc(ig1_loc, ig2, iw) + &
+                         X_full(ig1_sym, ig2_sym, iw) / real(nsym_loop, SP)
+                 endif
+              endif
+           enddo
+        enddo
+     enddo
+  enddo
+  
+  deallocate(X_full)
+
+end subroutine X_symmetrize_q0

--- a/src/pol_function/X_dielectric_matrix.F
+++ b/src/pol_function/X_dielectric_matrix.F
@@ -497,6 +497,7 @@ subroutine X_symmetrize_q0(X_par, NG, Xw)
   use R_lattice,     ONLY: g_rot
   use parallel_int,  ONLY: PP_redux_wait
   use com,           ONLY: msg
+  use stderr,        ONLY: write_to_log
 
   implicit none
 
@@ -507,18 +508,22 @@ subroutine X_symmetrize_q0(X_par, NG, Xw)
   integer :: ig1, ig2, ig1_sym, ig2_sym, isym, iw
   integer :: nsym_loop, ig1_loc
   complex(SP), allocatable :: X_full(:,:)
+  logical :: saved_log
   !
   if (nsym <= 1) return
   !
-  call msg('r', 'Applying q->0 symmetries to the macroscopic dielectric matrix')
+  saved_log = write_to_log
+  if (X_par%INTER_comm%CPU_id == 0) write_to_log = .TRUE.
+  call msg('s', 'Applying q->0 symmetries to the macroscopic dielectric matrix')
+  write_to_log = saved_log
   !
   allocate(X_full(NG, NG))
   ! 
   do iw = 1, Xw%n_freqs  
      X_full = cZERO
-     if (X_par%nrows>0) X_full(X_par%rows(1):X_par%rows(2), 1:NG) = X_par%blc(1:X_par%nrows, 1:NG, iw)
+     if (X_par%nrows>0) X_full(X_par%rows(1):X_par%rows(2), 1:NG) = X_par%blc(X_par%rows(1):X_par%rows(2), 1:NG, iw)
      call PP_redux_wait(X_full, COMM=X_par%INTER_comm%COMM)
-     if (X_par%nrows>0) X_par%blc(1:X_par%nrows, 1:NG, iw) = cZERO
+     if (X_par%nrows>0) X_par%blc(X_par%rows(1):X_par%rows(2), 1:NG, iw) = cZERO
      ! Note :
      ! Time reversal maps (X(q,...,E) to X(q,...,-E)
      ! so we only apply to E = 0 case
@@ -536,10 +541,10 @@ subroutine X_symmetrize_q0(X_par, NG, Xw)
               !
               if (ig1_sym > 0 .and. ig1_sym <= NG .and. ig2_sym > 0 .and. ig2_sym <= NG) then
                  if (isym > nsym / (i_time_rev + 1)) then
-                    X_par%blc(ig1_loc, ig2, iw) = X_par%blc(ig1_loc, ig2, iw) + &
+                    X_par%blc(ig1, ig2, iw) = X_par%blc(ig1, ig2, iw) + &
                          conjg(X_full(ig1_sym, ig2_sym)) / real(nsym_loop, SP)
                  else
-                    X_par%blc(ig1_loc, ig2, iw) = X_par%blc(ig1_loc, ig2, iw) + &
+                    X_par%blc(ig1, ig2, iw) = X_par%blc(ig1, ig2, iw) + &
                          X_full(ig1_sym, ig2_sym) / real(nsym_loop, SP)
                  endif
               endif

--- a/src/pol_function/X_dielectric_matrix.F
+++ b/src/pol_function/X_dielectric_matrix.F
@@ -506,49 +506,48 @@ subroutine X_symmetrize_q0(X_par, NG, Xw)
 
   integer :: ig1, ig2, ig1_sym, ig2_sym, isym, iw
   integer :: nsym_loop, ig1_loc
-  complex(SP), allocatable :: X_full(:,:,:)
-
+  complex(SP), allocatable :: X_full(:,:)
+  !
   if (nsym <= 1) return
-
+  !
   call msg('r', 'Applying q->0 symmetries to the macroscopic dielectric matrix')
-
-  allocate(X_full(NG, NG, Xw%n_freqs))
-  X_full = cZERO
-  
-  if (X_par%nrows>0) X_full(X_par%rows(1):X_par%rows(2), 1:NG, :) = X_par%blc(1:X_par%nrows, 1:NG, :)
-  
-  call PP_redux_wait(X_full, COMM=X_par%INTER_comm%COMM)
-  
-  X_par%blc = cZERO
-  
-  do iw = 1, Xw%n_freqs
+  !
+  allocate(X_full(NG, NG))
+  ! 
+  do iw = 1, Xw%n_freqs  
+     X_full = cZERO
+     if (X_par%nrows>0) X_full(X_par%rows(1):X_par%rows(2), 1:NG) = X_par%blc(1:X_par%nrows, 1:NG, iw)
+     call PP_redux_wait(X_full, COMM=X_par%INTER_comm%COMM)
+     if (X_par%nrows>0) X_par%blc(1:X_par%nrows, 1:NG, iw) = cZERO
+     ! Note :
+     ! Time reversal maps (X(q,...,E) to X(q,...,-E)
+     ! so we only apply to E = 0 case
      if (abs(Xw%p(iw)) < 1.e-5_SP) then
         nsym_loop = nsym
      else
         nsym_loop = nsym / (i_time_rev + 1)
      endif
-
      do ig2 = 1, NG
         do ig1_loc = 1, X_par%nrows
            ig1 = ig1_loc + X_par%rows(1) - 1
            do isym = 1, nsym_loop
               ig1_sym = g_rot(ig1, isym)
               ig2_sym = g_rot(ig2, isym)
-              
+              !
               if (ig1_sym > 0 .and. ig1_sym <= NG .and. ig2_sym > 0 .and. ig2_sym <= NG) then
                  if (isym > nsym / (i_time_rev + 1)) then
                     X_par%blc(ig1_loc, ig2, iw) = X_par%blc(ig1_loc, ig2, iw) + &
-                         conjg(X_full(ig1_sym, ig2_sym, iw)) / real(nsym_loop, SP)
+                         conjg(X_full(ig1_sym, ig2_sym)) / real(nsym_loop, SP)
                  else
                     X_par%blc(ig1_loc, ig2, iw) = X_par%blc(ig1_loc, ig2, iw) + &
-                         X_full(ig1_sym, ig2_sym, iw) / real(nsym_loop, SP)
+                         X_full(ig1_sym, ig2_sym) / real(nsym_loop, SP)
                  endif
               endif
            enddo
         enddo
      enddo
   enddo
-  
+  !
   deallocate(X_full)
-
+!
 end subroutine X_symmetrize_q0

--- a/src/pol_function/X_dielectric_matrix.F
+++ b/src/pol_function/X_dielectric_matrix.F
@@ -507,7 +507,6 @@ subroutine X_symmetrize_q0(X_par, NG, Xw)
   integer :: ig1, ig2, ig1_sym, ig2_sym, isym, iw
   integer :: nsym_loop, ig1_loc
   complex(SP), allocatable :: X_full(:,:)
-  logical :: saved_log
   !
   if (nsym <= 1) return
   !

--- a/src/pol_function/X_dielectric_matrix.F
+++ b/src/pol_function/X_dielectric_matrix.F
@@ -497,7 +497,6 @@ subroutine X_symmetrize_q0(X_par, NG, Xw)
   use R_lattice,     ONLY: g_rot
   use parallel_int,  ONLY: PP_redux_wait
   use com,           ONLY: msg
-  use stderr,        ONLY: write_to_log
 
   implicit none
 
@@ -512,10 +511,7 @@ subroutine X_symmetrize_q0(X_par, NG, Xw)
   !
   if (nsym <= 1) return
   !
-  saved_log = write_to_log
-  if (X_par%INTER_comm%CPU_id == 0) write_to_log = .TRUE.
   call msg('s', 'Applying q->0 symmetries to the macroscopic dielectric matrix')
-  write_to_log = saved_log
   !
   allocate(X_full(NG, NG))
   ! 


### PR DESCRIPTION
The code gives incorrect results when performing BSE calculations on systems with only a single Gamma point (e.g. molecules). The issue arises because, when computing $W(q \to 0)$, we choose a specific direction, which is no longer symmetric with respect to the point group. Therefore, this contribution should be symmetrized. The proper fix would be to perform a RIM treatment for W over several q-points, but that is considerably more demanding.

In this PR, I implement an alternative workaround for cases where the user enables symmetries (this should be a robust fix as long as symmetries are used). The idea is to rotate $\epsilon$ over all symmetry operations and average the result. In this approach, we explicitly avoid computing $\chi_0$ for more than a single $q \to 0$ point.

In addition, I slightly adjusted the `Lkind` defaults. With the current implementation, the fix can break down easily if `Lbar` is not specified correctly, and I think the existing way is too aggressive.

I also have one question:

1. I am not sure whether I am using the correct communicator to gather $X(G,G')$ onto a single CPU. Currently I am doing (it works, but please cross check):

```fortran
if (X_par%nrows>0) X_full(X_par%rows(1):X_par%rows(2), 1:NG) = X_par%blc(1:X_par%nrows, 1:NG, iw)
call PP_redux_wait(X_full, COMM=X_par%INTER_comm%COMM)
if (X_par%nrows>0) X_par%blc(1:X_par%nrows, 1:NG, iw) = cZERO
```

Is this the correct approach, or should I instead use a different communicator / reduction routine here?


Tested on SiH4
old BSE energies at Q=0
```
    0.08776613       8.33745301e-03          1
      0.11589517       1.20850524e-03          2
      0.15104856       3.88729223e-03          3
      0.32560593       4.40265499e-02          4
      0.35400522       3.05387867e-03          5
      0.36274657       1.34110535e-02          6
      0.43202174       4.83342893e-02          7
      0.46968186       6.08044565e-02          8
      0.51835233       2.47406457e-02          9
      0.55277359       2.40801051e-01         10
      0.58717853       3.59762572e-02         11
      0.61871099       3.44642907e-01         12
      0.64019614       1.67792067e-01         13
      0.66484177       3.51507291e-02         14
      0.68922377       2.67852675e-02         15
      0.71332335       5.36881149e-01         16
      0.73797375       3.09134752e-01         17
      0.77709079       6.68502450e-02         18
      1.42262530       1.62761547e-02         19
      1.42498660       1.05558652e-02         20

```


new
```
      0.15306734       4.93323887e-06          1
      0.15328379       1.20675338e-07          2
      0.15377326       7.34474859e-04          3
      0.39103109       1.86077710e-02          4
      0.39110294       3.34145315e-03          5
      0.39134952       2.39068162e-04          6
      0.54828960       5.36223115e-06          7
      0.57273978       9.17885998e-08          8
      0.57323676       1.04717208e-06          9
      0.57616794       5.25700525e-05         10
      0.57637793       1.10940891e-05         11
      0.57665282       9.54457282e-05         12
      0.63472039       1.02440258e-02         13
      0.63489306       3.45902830e-01         14
      0.63537771       1.50725543e-01         15
      0.69839782       6.42127618e-02         16
      0.69868815       4.33492869e-01         17
      0.69879669       5.25059029e-02         18
      1.44143164       1.41905184e-06         19
      1.44206464       1.60859628e-07         20
```


the first three excitons must be degenerate


<img width="1000" height="600" alt="xxxx11" src="https://github.com/user-attachments/assets/9ecce632-2367-4e8f-ba99-1c9c9e8df982" />
